### PR TITLE
Add move logic for all pieces (in chess) + tests

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
   "singleQuote": true,
-  "printWidth": 80,
+  "printWidth": 120,
   "proseWrap": "always",
   "tabWidth": 2,
   "useTabs": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.formatOnSaveMode": "modificationsIfAvailable",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It should:
 
 ## Testing
 
-Since `jest` runs on `Node.js` and `Node.js` doesn't support ECMAScript Modules natively, `babel.js` (babel-jest) is
+Since `jest` runs on `Node.js` and `Node.js` doesn't support ECMAScript-Modules (it's CommonJS) natively, `babel.js` (babel-jest) is
 used as plugin to transform the code, allowing imports from other files. To test you need to:
 
 `npm run test`

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ It should:
 
 ## Testing
 
-Since `jest` runs on `Node.js` and `Node.js` doesn't support ECMAScript Modules natively, `babel.js` (babel-jest) is used as plugin to transform the code, allowing imports from other files. To test you need to:
+Since `jest` runs on `Node.js` and `Node.js` doesn't support ECMAScript Modules natively, `babel.js` (babel-jest) is
+used as plugin to transform the code, allowing imports from other files. To test you need to:
 
 `npm run test`
 
-For some reason an approach without babel failed - `ts-jest` should be an
-alternative.
+For some reason an approach without babel failed - `ts-jest` should be an alternative.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,19 +1,3 @@
-// export default {
-//   presets: [
-//     [
-//       '@babel/preset-env',
-//       {
-//         targets: {
-//           node: 'current',
-//         },
-//       },
-//     ],
-//   ],
-// };
-
 export default {
-  presets: [
-    ['@babel/preset-env', { targets: { node: 'current' } }],
-    '@babel/preset-typescript',
-  ],
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,10 +19,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': [
         'warn', // or "error"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "prettier": "^3.6.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "ts-pattern": "^5.8.0"
       },
       "devDependencies": {
         "@babel/core": "^7.28.4",
@@ -8977,6 +8978,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/ts-pattern": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.8.0.tgz",
+      "integrity": "sha512-kIjN2qmWiHnhgr5DAkAafF9fwb0T5OhMVSWrm8XEdTFnX6+wfXwYOFjeF86UZ54vduqiR7BfqScFmXSzSaH8oA==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
     "fmt": "prettier . --write",
-    "test": "node --experimental-require-module  ./node_modules/.bin/jest --config ./jest.config.ts",
+    "test": "node --experimental-require-module  ./node_modules/.bin/jest --config ./jest.config.ts --silent=false",
     "test:geometry": "node --experimental-require-module  ./node_modules/.bin/jest --config ./jest.config.ts src/__test__/geometry/*"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "preview": "vite preview",
     "fmt": "prettier . --write",
     "test": "node --experimental-require-module  ./node_modules/.bin/jest --config ./jest.config.ts --silent=false",
-    "test:geometry": "node --experimental-require-module  ./node_modules/.bin/jest --config ./jest.config.ts src/__test__/geometry/*"
+    "test:geometry": "node --experimental-require-module  ./node_modules/.bin/jest --config ./jest.config.ts src/__test__/geometry/*",
+    "test:geometry::check": "node --experimental-require-module  ./node_modules/.bin/jest --config ./jest.config.ts src/__test__/geometry/check.test.ts",
+    "test:geometry::move": "node --experimental-require-module  ./node_modules/.bin/jest --config ./jest.config.ts src/__test__/geometry/move.test.ts"
   },
   "dependencies": {
     "eslint-plugin-jest": "^29.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "prettier": "^3.6.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "ts-pattern": "^5.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",

--- a/src/__test__/geometry/board.test.ts
+++ b/src/__test__/geometry/board.test.ts
@@ -1,5 +1,5 @@
-import { createChessBoardFromFen } from '../../geometry/board.ts';
 import { Fen } from '../../geometry/types.ts';
+import { createChessBoardFromFen } from '../../geometry/board.ts';
 import { INIT_POSITION } from '../../geometry/fen.ts';
 
 describe('Chess board creation from FEN', () => {
@@ -11,48 +11,44 @@ describe('Chess board creation from FEN', () => {
     const blackPieces = board.filter((piece) => piece.color === 'black');
     expect(whitePieces.length).toBe(16);
     expect(blackPieces.length).toBe(16);
-    expect(board.sort().reverse()).toEqual(
-      expect.arrayContaining(
-        [
-          { row: 1, column: 'a', figure: 'ROOK', color: 'white' },
-          { row: 1, column: 'b', figure: 'KNIGHT', color: 'white' },
-          { row: 1, column: 'c', figure: 'BISHOP', color: 'white' },
-          { row: 1, column: 'd', figure: 'QUEEN', color: 'white' },
-          { row: 1, column: 'e', figure: 'KING', color: 'white' },
-          { row: 1, column: 'f', figure: 'BISHOP', color: 'white' },
-          { row: 1, column: 'g', figure: 'KNIGHT', color: 'white' },
-          { row: 1, column: 'h', figure: 'ROOK', color: 'white' },
+    expect(board).toEqual(
+      expect.arrayContaining([
+        { row: 1, column: 'a', figure: 'ROOK', color: 'white' },
+        { row: 1, column: 'b', figure: 'KNIGHT', color: 'white' },
+        { row: 1, column: 'c', figure: 'BISHOP', color: 'white' },
+        { row: 1, column: 'd', figure: 'QUEEN', color: 'white' },
+        { row: 1, column: 'e', figure: 'KING', color: 'white' },
+        { row: 1, column: 'f', figure: 'BISHOP', color: 'white' },
+        { row: 1, column: 'g', figure: 'KNIGHT', color: 'white' },
+        { row: 1, column: 'h', figure: 'ROOK', color: 'white' },
 
-          { row: 2, column: 'a', figure: 'PAWN', color: 'white' },
-          { row: 2, column: 'b', figure: 'PAWN', color: 'white' },
-          { row: 2, column: 'c', figure: 'PAWN', color: 'white' },
-          { row: 2, column: 'd', figure: 'PAWN', color: 'white' },
-          { row: 2, column: 'e', figure: 'PAWN', color: 'white' },
-          { row: 2, column: 'f', figure: 'PAWN', color: 'white' },
-          { row: 2, column: 'g', figure: 'PAWN', color: 'white' },
-          { row: 2, column: 'h', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'a', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'b', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'c', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'd', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'e', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'f', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'g', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'h', figure: 'PAWN', color: 'white' },
 
-          { row: 8, column: 'a', figure: 'ROOK', color: 'black' },
-          { row: 8, column: 'b', figure: 'KNIGHT', color: 'black' },
-          { row: 8, column: 'c', figure: 'BISHOP', color: 'black' },
-          { row: 8, column: 'd', figure: 'QUEEN', color: 'black' },
-          { row: 8, column: 'e', figure: 'KING', color: 'black' },
-          { row: 8, column: 'f', figure: 'BISHOP', color: 'black' },
-          { row: 8, column: 'g', figure: 'KNIGHT', color: 'black' },
-          { row: 8, column: 'h', figure: 'ROOK', color: 'black' },
+        { row: 8, column: 'a', figure: 'ROOK', color: 'black' },
+        { row: 8, column: 'b', figure: 'KNIGHT', color: 'black' },
+        { row: 8, column: 'c', figure: 'BISHOP', color: 'black' },
+        { row: 8, column: 'd', figure: 'QUEEN', color: 'black' },
+        { row: 8, column: 'e', figure: 'KING', color: 'black' },
+        { row: 8, column: 'f', figure: 'BISHOP', color: 'black' },
+        { row: 8, column: 'g', figure: 'KNIGHT', color: 'black' },
+        { row: 8, column: 'h', figure: 'ROOK', color: 'black' },
 
-          { row: 7, column: 'a', figure: 'PAWN', color: 'black' },
-          { row: 7, column: 'b', figure: 'PAWN', color: 'black' },
-          { row: 7, column: 'c', figure: 'PAWN', color: 'black' },
-          { row: 7, column: 'd', figure: 'PAWN', color: 'black' },
-          { row: 7, column: 'e', figure: 'PAWN', color: 'black' },
-          { row: 7, column: 'f', figure: 'PAWN', color: 'black' },
-          { row: 7, column: 'g', figure: 'PAWN', color: 'black' },
-          { row: 7, column: 'h', figure: 'PAWN', color: 'black' },
-        ]
-          .sort()
-          .reverse(),
-      ),
+        { row: 7, column: 'a', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'b', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'c', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'd', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'e', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'f', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'g', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'h', figure: 'PAWN', color: 'black' },
+      ]),
     );
   });
 });

--- a/src/__test__/geometry/board.test.ts
+++ b/src/__test__/geometry/board.test.ts
@@ -1,0 +1,58 @@
+import { createChessBoardFromFen } from '../../geometry/board.ts';
+import { Fen } from '../../geometry/types.ts';
+import { INIT_POSITION } from '../../geometry/fen.ts';
+
+describe('Chess board creation from FEN', () => {
+  it('creates the correct board from the initial position FEN', () => {
+    const initPos: Fen = INIT_POSITION;
+    const board = createChessBoardFromFen(initPos);
+    expect(board.length).toBe(32); // 32 pieces in total
+    const whitePieces = board.filter((piece) => piece.color === 'white');
+    const blackPieces = board.filter((piece) => piece.color === 'black');
+    expect(whitePieces.length).toBe(16);
+    expect(blackPieces.length).toBe(16);
+    expect(board.sort().reverse()).toEqual(
+      expect.arrayContaining(
+        [
+          { row: 1, column: 'a', figure: 'ROOK', color: 'white' },
+          { row: 1, column: 'b', figure: 'KNIGHT', color: 'white' },
+          { row: 1, column: 'c', figure: 'BISHOP', color: 'white' },
+          { row: 1, column: 'd', figure: 'QUEEN', color: 'white' },
+          { row: 1, column: 'e', figure: 'KING', color: 'white' },
+          { row: 1, column: 'f', figure: 'BISHOP', color: 'white' },
+          { row: 1, column: 'g', figure: 'KNIGHT', color: 'white' },
+          { row: 1, column: 'h', figure: 'ROOK', color: 'white' },
+
+          { row: 2, column: 'a', figure: 'PAWN', color: 'white' },
+          { row: 2, column: 'b', figure: 'PAWN', color: 'white' },
+          { row: 2, column: 'c', figure: 'PAWN', color: 'white' },
+          { row: 2, column: 'd', figure: 'PAWN', color: 'white' },
+          { row: 2, column: 'e', figure: 'PAWN', color: 'white' },
+          { row: 2, column: 'f', figure: 'PAWN', color: 'white' },
+          { row: 2, column: 'g', figure: 'PAWN', color: 'white' },
+          { row: 2, column: 'h', figure: 'PAWN', color: 'white' },
+
+          { row: 8, column: 'a', figure: 'ROOK', color: 'black' },
+          { row: 8, column: 'b', figure: 'KNIGHT', color: 'black' },
+          { row: 8, column: 'c', figure: 'BISHOP', color: 'black' },
+          { row: 8, column: 'd', figure: 'QUEEN', color: 'black' },
+          { row: 8, column: 'e', figure: 'KING', color: 'black' },
+          { row: 8, column: 'f', figure: 'BISHOP', color: 'black' },
+          { row: 8, column: 'g', figure: 'KNIGHT', color: 'black' },
+          { row: 8, column: 'h', figure: 'ROOK', color: 'black' },
+
+          { row: 7, column: 'a', figure: 'PAWN', color: 'black' },
+          { row: 7, column: 'b', figure: 'PAWN', color: 'black' },
+          { row: 7, column: 'c', figure: 'PAWN', color: 'black' },
+          { row: 7, column: 'd', figure: 'PAWN', color: 'black' },
+          { row: 7, column: 'e', figure: 'PAWN', color: 'black' },
+          { row: 7, column: 'f', figure: 'PAWN', color: 'black' },
+          { row: 7, column: 'g', figure: 'PAWN', color: 'black' },
+          { row: 7, column: 'h', figure: 'PAWN', color: 'black' },
+        ]
+          .sort()
+          .reverse(),
+      ),
+    );
+  });
+});

--- a/src/__test__/geometry/board.test.ts
+++ b/src/__test__/geometry/board.test.ts
@@ -1,6 +1,6 @@
-import { Fen } from '../../geometry/types.ts';
-import { createChessBoardFromFen } from '../../geometry/board.ts';
-import { INIT_POSITION } from '../../geometry/fen.ts';
+import { Board, BoardPieceMap, Fen } from '../../geometry/types.ts';
+import { boardToColorMap, boardToPieceMap, createChessBoardFromFen } from '../../geometry/board.ts';
+import { INIT_POSITION } from '../../geometry/constant.ts';
 
 describe('Chess board creation from FEN', () => {
   it('creates the correct board from the initial position FEN', () => {
@@ -50,5 +50,161 @@ describe('Chess board creation from FEN', () => {
         { row: 7, column: 'h', figure: 'PAWN', color: 'black' },
       ]),
     );
+  });
+  it('creates a board from Fen with two moved pawns', () => {
+    const initPos: Fen = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2';
+    const board = createChessBoardFromFen(initPos);
+
+    expect(board.length).toBe(32); // 32 pieces in total
+    const whitePieces = board.filter((piece) => piece.color === 'white');
+    const blackPieces = board.filter((piece) => piece.color === 'black');
+    expect(whitePieces.length).toBe(16);
+    expect(blackPieces.length).toBe(16);
+    expect(board).toEqual(
+      expect.arrayContaining([
+        { row: 1, column: 'a', figure: 'ROOK', color: 'white' },
+        { row: 1, column: 'b', figure: 'KNIGHT', color: 'white' },
+        { row: 1, column: 'c', figure: 'BISHOP', color: 'white' },
+        { row: 1, column: 'd', figure: 'QUEEN', color: 'white' },
+        { row: 1, column: 'e', figure: 'KING', color: 'white' },
+        { row: 1, column: 'f', figure: 'BISHOP', color: 'white' },
+        { row: 1, column: 'g', figure: 'KNIGHT', color: 'white' },
+        { row: 1, column: 'h', figure: 'ROOK', color: 'white' },
+
+        { row: 2, column: 'a', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'b', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'c', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'd', figure: 'PAWN', color: 'white' },
+        // e2 pawn moved
+        { row: 4, column: 'e', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'f', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'g', figure: 'PAWN', color: 'white' },
+        { row: 2, column: 'h', figure: 'PAWN', color: 'white' },
+
+        { row: 8, column: 'a', figure: 'ROOK', color: 'black' },
+        { row: 8, column: 'b', figure: 'KNIGHT', color: 'black' },
+        { row: 8, column: 'c', figure: 'BISHOP', color: 'black' },
+        { row: 8, column: 'd', figure: 'QUEEN', color: 'black' },
+        { row: 8, column: 'e', figure: 'KING', color: 'black' },
+        { row: 8, column: 'f', figure: 'BISHOP', color: 'black' },
+        { row: 8, column: 'g', figure: 'KNIGHT', color: 'black' },
+        { row: 8, column: 'h', figure: 'ROOK', color: 'black' },
+
+        { row: 7, column: 'a', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'b', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'c', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'd', figure: 'PAWN', color: 'black' },
+        // e7 pawn moved
+        { row: 5, column: 'e', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'f', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'g', figure: 'PAWN', color: 'black' },
+        { row: 7, column: 'h', figure: 'PAWN', color: 'black' },
+      ]),
+    );
+  });
+});
+
+describe('board to board piece map and color map conversion', () => {
+  const board: Board = [
+    { row: 1, column: 'a', figure: 'ROOK', color: 'white' },
+    { row: 1, column: 'b', figure: 'KNIGHT', color: 'white' },
+    { row: 1, column: 'c', figure: 'BISHOP', color: 'white' },
+    { row: 1, column: 'd', figure: 'QUEEN', color: 'white' },
+    { row: 1, column: 'e', figure: 'KING', color: 'white' },
+    { row: 1, column: 'f', figure: 'BISHOP', color: 'white' },
+    { row: 1, column: 'g', figure: 'KNIGHT', color: 'white' },
+    { row: 1, column: 'h', figure: 'ROOK', color: 'white' },
+
+    { row: 2, column: 'a', figure: 'PAWN', color: 'white' },
+    { row: 2, column: 'b', figure: 'PAWN', color: 'white' },
+    { row: 2, column: 'c', figure: 'PAWN', color: 'white' },
+    { row: 2, column: 'd', figure: 'PAWN', color: 'white' },
+    // e2 pawn moved
+    { row: 4, column: 'e', figure: 'PAWN', color: 'white' },
+    { row: 2, column: 'f', figure: 'PAWN', color: 'white' },
+    { row: 2, column: 'g', figure: 'PAWN', color: 'white' },
+    { row: 2, column: 'h', figure: 'PAWN', color: 'white' },
+
+    { row: 7, column: 'a', figure: 'PAWN', color: 'black' },
+    { row: 7, column: 'b', figure: 'PAWN', color: 'black' },
+    { row: 7, column: 'c', figure: 'PAWN', color: 'black' },
+    { row: 7, column: 'd', figure: 'PAWN', color: 'black' },
+    // e7 pawn moved
+    { row: 5, column: 'e', figure: 'PAWN', color: 'black' },
+    { row: 7, column: 'f', figure: 'PAWN', color: 'black' },
+    { row: 7, column: 'g', figure: 'PAWN', color: 'black' },
+    { row: 7, column: 'h', figure: 'PAWN', color: 'black' },
+
+    { row: 8, column: 'a', figure: 'ROOK', color: 'black' },
+    { row: 8, column: 'b', figure: 'KNIGHT', color: 'black' },
+    { row: 8, column: 'c', figure: 'BISHOP', color: 'black' },
+    { row: 8, column: 'd', figure: 'QUEEN', color: 'black' },
+    { row: 8, column: 'e', figure: 'KING', color: 'black' },
+    { row: 8, column: 'f', figure: 'BISHOP', color: 'black' },
+    { row: 8, column: 'g', figure: 'KNIGHT', color: 'black' },
+    { row: 8, column: 'h', figure: 'ROOK', color: 'black' },
+  ];
+
+  it('creates correct piece map from given position', () => {
+    const boardPieceMap: BoardPieceMap = [
+      [
+        { figure: 'ROOK', color: 'white' },
+        { figure: 'KNIGHT', color: 'white' },
+        { figure: 'BISHOP', color: 'white' },
+        { figure: 'QUEEN', color: 'white' },
+        { figure: 'KING', color: 'white' },
+        { figure: 'BISHOP', color: 'white' },
+        { figure: 'KNIGHT', color: 'white' },
+        { figure: 'ROOK', color: 'white' },
+      ],
+      [
+        { figure: 'PAWN', color: 'white' },
+        { figure: 'PAWN', color: 'white' },
+        { figure: 'PAWN', color: 'white' },
+        { figure: 'PAWN', color: 'white' },
+        null,
+        { figure: 'PAWN', color: 'white' },
+        { figure: 'PAWN', color: 'white' },
+        { figure: 'PAWN', color: 'white' },
+      ],
+      [null, null, null, null, null, null, null, null],
+      [null, null, null, null, { figure: 'PAWN', color: 'white' }, null, null, null],
+      [null, null, null, null, { figure: 'PAWN', color: 'black' }, null, null, null],
+      [null, null, null, null, null, null, null, null],
+      [
+        { figure: 'PAWN', color: 'black' },
+        { figure: 'PAWN', color: 'black' },
+        { figure: 'PAWN', color: 'black' },
+        { figure: 'PAWN', color: 'black' },
+        null,
+        { figure: 'PAWN', color: 'black' },
+        { figure: 'PAWN', color: 'black' },
+        { figure: 'PAWN', color: 'black' },
+      ],
+      [
+        { figure: 'ROOK', color: 'black' },
+        { figure: 'KNIGHT', color: 'black' },
+        { figure: 'BISHOP', color: 'black' },
+        { figure: 'QUEEN', color: 'black' },
+        { figure: 'KING', color: 'black' },
+        { figure: 'BISHOP', color: 'black' },
+        { figure: 'KNIGHT', color: 'black' },
+        { figure: 'ROOK', color: 'black' },
+      ],
+    ];
+    expect(boardToPieceMap(board)).toEqual(boardPieceMap);
+  });
+  it('creates correct color map from given position', () => {
+    const boardColorMap = [
+      ['white', 'white', 'white', 'white', 'white', 'white', 'white', 'white'],
+      ['white', 'white', 'white', 'white', 'none', 'white', 'white', 'white'],
+      ['none', 'none', 'none', 'none', 'none', 'none', 'none', 'none'],
+      ['none', 'none', 'none', 'none', 'white', 'none', 'none', 'none'],
+      ['none', 'none', 'none', 'none', 'black', 'none', 'none', 'none'],
+      ['none', 'none', 'none', 'none', 'none', 'none', 'none', 'none'],
+      ['black', 'black', 'black', 'black', 'none', 'black', 'black', 'black'],
+      ['black', 'black', 'black', 'black', 'black', 'black', 'black', 'black'],
+    ];
+    expect(boardToColorMap(board)).toEqual(boardColorMap);
   });
 });

--- a/src/__test__/geometry/check.test.ts
+++ b/src/__test__/geometry/check.test.ts
@@ -14,13 +14,21 @@ describe('King is checked', () => {
     expect(resNotChecked).not.toBe(true);
   });
   it('proves that black king on g8 is checked in rook direction', () => {
-    const boardRook = createChessBoardFromFen('6k1/p7/8/8/8/8/6R1/2K5 w - - 0 1');
+    const boardRook = createChessBoardFromFen('6k1/p7/8/8/8/8/6R1/2K5 w - - 0 1'); //vertical rook
+    const boardRook2 = createChessBoardFromFen('8/8/8/3R3k/3K4/8/8/8 w - - 0 1'); //horizontal rook
+    const boardRook3 = createChessBoardFromFen('8/8/8/3R2k1/3K4/8/8/8 w - - 0 1'); //horizontal rook
     const boardQueen = createChessBoardFromFen('6k1/p7/8/8/8/8/6Q1/2K5 w - - 0 1');
     const boardNotChecked = createChessBoardFromFen('3RQ3/p6R/5k2/7R/8/6R1/3K4/8 w - - 0 1');
     const resR = isKingChecked(boardRook, 'black');
+    const resR2 = isKingChecked(boardRook2, 'black');
+    const resR3 = isKingChecked(boardRook3, 'black');
     const resQ = isKingChecked(boardQueen, 'black');
     const resNotChecked = isKingChecked(boardNotChecked, 'black');
+    const resR3PositionChecked = isKingChecked(boardRook3, 'black');
     expect(resR).toBe(true);
+    expect(resR2).toBe(true);
+    expect(resR3).toBe(true);
+    expect(resR3PositionChecked).toBe(true);
     expect(resQ).toBe(true);
     expect(resNotChecked).not.toBe(true);
   });

--- a/src/__test__/geometry/check.test.ts
+++ b/src/__test__/geometry/check.test.ts
@@ -1,4 +1,105 @@
+import { createChessBoardFromFen } from '../../geometry/board.ts';
 import { isKingChecked } from '../../geometry/check.ts';
+import { INIT_POSITION } from '../../geometry/constant.ts';
 describe('King is checked', () => {
-  it('proves that king is checked in bishop direction', () => {});
+  it('proves that black king on h8 is checked in bishop direction (by queen and bishop)', () => {
+    const boardBishop = createChessBoardFromFen('7k/8/8/8/3B4/8/5K2/8 w - - 0 1');
+    const boardQueen = createChessBoardFromFen('7k/p7/8/8/8/8/1Q6/2K5 w - - 0 1');
+    const boardNotChecked = createChessBoardFromFen('8/p7/5k2/8/8/4B2B/3K4/8 w - - 0 1');
+    const resB = isKingChecked(boardBishop, 'black');
+    const resQ = isKingChecked(boardQueen, 'black');
+    const resNotChecked = isKingChecked(boardNotChecked, 'black');
+    expect(resB).toBe(true);
+    expect(resQ).toBe(true);
+    expect(resNotChecked).not.toBe(true);
+  });
+  it('proves that black king on g8 is checked in rook direction', () => {
+    const boardRook = createChessBoardFromFen('6k1/p7/8/8/8/8/6R1/2K5 w - - 0 1');
+    const boardQueen = createChessBoardFromFen('6k1/p7/8/8/8/8/6Q1/2K5 w - - 0 1');
+    const boardNotChecked = createChessBoardFromFen('3RQ3/p6R/5k2/7R/8/6R1/3K4/8 w - - 0 1');
+    const resR = isKingChecked(boardRook, 'black');
+    const resQ = isKingChecked(boardQueen, 'black');
+    const resNotChecked = isKingChecked(boardNotChecked, 'black');
+    expect(resR).toBe(true);
+    expect(resQ).toBe(true);
+    expect(resNotChecked).not.toBe(true);
+  });
+  it('proves that king gets checked by knight', () => {
+    const boardKnight = createChessBoardFromFen('8/p7/5k2/8/6N1/8/3K4/8 w - - 0 1');
+    const boardKnight2 = createChessBoardFromFen('8/p7/5k2/3N4/8/3K4/8/8 w - - 0 1');
+    const boardNotChecked = createChessBoardFromFen('8/p7/5k2/8/8/6N1/3K4/8 w - - 0 1');
+    const resN = isKingChecked(boardKnight, 'black');
+    const resN2 = isKingChecked(boardKnight2, 'black');
+    expect(resN).toBe(true);
+    expect(resN2).toBe(true);
+    expect(boardNotChecked).not.toBe(true);
+  });
+
+  it('proves that king gets checked by pawn from the left and right (both direction)', () => {
+    const boardPawnLeft = createChessBoardFromFen('7k/p5P1/8/8/8/6R1/Q7/2K5 w - - 0 1');
+    const boardPawnRight = createChessBoardFromFen('8/p7/5k2/3P2P1/8/3p4/3K4/8 w - - 0 1');
+    const boardPawnLeftW = createChessBoardFromFen('8/p7/5k2/3P4/8/4p3/3K4/8 w - - 0 1');
+    const boardPawnRightW = createChessBoardFromFen('8/p7/5k2/3P4/8/2p5/3K4/8 w - - 0 1');
+    const resPL = isKingChecked(boardPawnLeft, 'black');
+    const resPR = isKingChecked(boardPawnRight, 'black');
+    const resPLW = isKingChecked(boardPawnLeftW, 'white');
+    const resPRW = isKingChecked(boardPawnRightW, 'white');
+    expect(resPL).toBe(true);
+    expect(resPR).toBe(true);
+    expect(resPRW).toBe(true);
+    expect(resPLW).toBe(true);
+  });
+  it('proves that king not checked by pawn when pawn is in front of next to king (both directions)', () => {
+    const boardPawnFront = createChessBoardFromFen('8/p6R/5k2/3P1P2/8/6R1/3K4/8 w - - 0 1');
+    const boardPawnFrontW = createChessBoardFromFen('8/p6R/5k2/3P1P2/8/3p2R1/3K4/8 w - - 0 1');
+    const boardPawnNextToWhiteKing = createChessBoardFromFen('8/p7/5k2/3P4/8/8/3Kp3/8 w - - 0 1');
+    const boardPawnNextToBlackKing = createChessBoardFromFen('8/p7/5kP1/8/3p4/8/3K4/8 w - - 0 1');
+    const resP = isKingChecked(boardPawnFront, 'black');
+    const resPW = isKingChecked(boardPawnFrontW, 'white');
+    const resNP = isKingChecked(boardPawnNextToBlackKing, 'black');
+    const resNPW = isKingChecked(boardPawnNextToWhiteKing, 'white');
+    expect(resP).toBe(false);
+    expect(resPW).toBe(false);
+    expect(resNP).toBe(false);
+    expect(resNPW).toBe(false);
+  });
+  it('proves that king gets not checked from behind by pawn (both directions)', () => {
+    const boardPawnBehind = createChessBoardFromFen('8/p5P1/5k2/8/8/8/3K4/5p2 w - - 0 1');
+    const boardPawnBehindW = createChessBoardFromFen('8/p7/5k2/8/8/3K4/4p3/8 w - - 0 1');
+    const resPB = isKingChecked(boardPawnBehind, 'black');
+    const resPBW = isKingChecked(boardPawnBehindW, 'white');
+    expect(resPB).toBe(false);
+    expect(resPBW).toBe(false);
+  });
+
+  it('proves hypothetical check by opponent king', () => {
+    const board = createChessBoardFromFen('7k/p5K1/8/8/8/8/8/8 w - - 0 1');
+    const board2 = createChessBoardFromFen('8/p5K1/5k2/8/8/8/8/8 w - - 0 1');
+    const boardKingDontHitEachOther = createChessBoardFromFen('8/8/5k2/8/8/3K4/8/8 w - - 0 1');
+    const res = isKingChecked(board, 'black');
+    const res2 = isKingChecked(board2, 'black');
+    const res3 = isKingChecked(board, 'white');
+    const res4 = isKingChecked(board2, 'white');
+    const res5 = isKingChecked(boardKingDontHitEachOther, 'white');
+    expect(res).toBe(true);
+    expect(res2).toBe(true);
+    expect(res3).toBe(true);
+    expect(res4).toBe(true);
+    expect(res5).toBe(false);
+  });
+
+  it('proves that king is not checked when no pieces are attacking it', () => {
+    const board = createChessBoardFromFen(INIT_POSITION);
+    const res = isKingChecked(board, 'black');
+    expect(res).toBe(false);
+  });
+
+  it('proves that king gets checked by one of two pieces', () => {
+    const boardRookAndQueen = createChessBoardFromFen('7k/p7/8/8/8/7R/1Q6/2K5 w - - 0 1');
+    const boardPawnAndQueen = createChessBoardFromFen('7k/p5P1/8/8/8/7R/1Q6/2K5 w - - 0 1');
+    const resRQ = isKingChecked(boardRookAndQueen, 'black');
+    const resRP = isKingChecked(boardPawnAndQueen, 'black');
+    expect(resRQ).toBe(true);
+    expect(resRP).toBe(true);
+  });
 });

--- a/src/__test__/geometry/check.test.ts
+++ b/src/__test__/geometry/check.test.ts
@@ -1,5 +1,5 @@
 import { createChessBoardFromFen } from '../../geometry/board.ts';
-import { isKingChecked } from '../../geometry/check.ts';
+import { isKingChecked, isPositionChecked, wouldPositionBeChecked } from '../../geometry/check.ts';
 import { INIT_POSITION } from '../../geometry/constant.ts';
 describe('King is checked', () => {
   it('proves that black king on h8 is checked in bishop direction (by queen and bishop)', () => {
@@ -109,5 +109,13 @@ describe('King is checked', () => {
     const resRP = isKingChecked(boardPawnAndQueen, 'black');
     expect(resRQ).toBe(true);
     expect(resRP).toBe(true);
+  });
+  it('checks position for move.test.ts', () => {
+    //const board = createChessBoardFromFen('rn1qk2r/pppppppp/6n1/2N5/1R6/2Q5/PPbPPP2/4KB1R w kq - 0 1');
+    const board = createChessBoardFromFen('rn1qk2r/pppppppp/6n1/8/8/N1Q5/PPbPPP2/R3KB1R w kq - 0 1');
+    const res = wouldPositionBeChecked(board, { row: 1, column: 'd' }, 'white');
+    const res2 = isPositionChecked({ row: 1, column: 'b' }, board, 'white');
+    expect(res).toBe(true);
+    expect(res2).toBe(true);
   });
 });

--- a/src/__test__/geometry/check.test.ts
+++ b/src/__test__/geometry/check.test.ts
@@ -1,0 +1,4 @@
+import { isKingChecked } from '../../geometry/check.ts';
+describe('King is checked', () => {
+  it('proves that king is checked in bishop direction', () => {});
+});

--- a/src/__test__/geometry/check.test.ts
+++ b/src/__test__/geometry/check.test.ts
@@ -110,12 +110,20 @@ describe('King is checked', () => {
     expect(resRQ).toBe(true);
     expect(resRP).toBe(true);
   });
-  it('checks position for move.test.ts', () => {
-    //const board = createChessBoardFromFen('rn1qk2r/pppppppp/6n1/2N5/1R6/2Q5/PPbPPP2/4KB1R w kq - 0 1');
+  it('validates check for specific position', () => {
     const board = createChessBoardFromFen('rn1qk2r/pppppppp/6n1/8/8/N1Q5/PPbPPP2/R3KB1R w kq - 0 1');
-    const res = wouldPositionBeChecked(board, { row: 1, column: 'd' }, 'white');
+    const res = isPositionChecked({ row: 1, column: 'd' }, board, 'white');
     const res2 = isPositionChecked({ row: 1, column: 'b' }, board, 'white');
     expect(res).toBe(true);
     expect(res2).toBe(true);
   });
+  it('validates check from behind', () => {
+    const board = createChessBoardFromFen('rn1qk2r/pppppppp/6n1/8/8/N1Q1P3/PP2PPb1/R3Kr1R w kq - 0 1');
+    const res = isKingChecked(board, 'white');
+    const resPos = isPositionChecked({ row: 1, column: 'd' }, board, 'white');
+    const resPos2 = isPositionChecked({ row: 2, column: 'd' }, board, 'white');
+    expect(res).toBe(true);
+    expect(resPos).toBe(true);
+    expect(resPos2).toBe(false);
+  }); 
 });

--- a/src/__test__/geometry/fen.test.ts
+++ b/src/__test__/geometry/fen.test.ts
@@ -1,24 +1,24 @@
-import { isValidFENSyntax, INIT_POSITION } from '../../geometry/fen.ts';
+import { isValidFenSyntax, INIT_POSITION } from '../../geometry/fen.ts';
 import { Fen } from '../../geometry/types.ts';
 
-describe('regex match for FEN module', () => {
+describe('regex match for Fen module', () => {
   //true take
   it('checks an init FEN returning true', () => {
-    expect(isValidFENSyntax(INIT_POSITION)).toBe(true);
+    expect(isValidFenSyntax(INIT_POSITION)).toBe(true);
   });
   it('checks some edited valid FEN returning true. 2 pawns less', () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(true);
+    expect(isValidFenSyntax(someFEN)).toBe(true);
   });
   it('checks some edited valid FEN returning true. edited half moves', () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 2 1';
-    expect(isValidFENSyntax(someFEN)).toBe(true);
+    expect(isValidFenSyntax(someFEN)).toBe(true);
   });
   it('checks correct FEN with enpassent move to be true', () => {
     const someFEN: Fen = 'rnbq1rk1/p1p1bppp/5n2/1pPpp3/4P3/3P1N2/PP2BPPP/RNBQ1RK1 w - d6 0 8';
     const someFEN2: Fen = 'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 3';
-    expect(isValidFENSyntax(someFEN)).toBe(true);
-    expect(isValidFENSyntax(someFEN2)).toBe(true);
+    expect(isValidFenSyntax(someFEN)).toBe(true);
+    expect(isValidFenSyntax(someFEN2)).toBe(true);
   });
   it('should pass on vanished or manipulated castling rights. ', () => {
     const someFEN: Fen = 'rnbq1rk1/pppp1ppp/3b1n2/4p3/4P3/3P1N2/PPP1BPPP/RNBQ1RK1 b - - 4 5';
@@ -28,54 +28,54 @@ describe('regex match for FEN module', () => {
     const someFEN4: Fen = 'r1b1kbnr/ppp2ppp/2nqp3/3p4/3P4/2NQB3/PPP1PPPP/2KR1BNR b kq - 1 5';
     const someFEN5: Fen = 'r3kr2/pppbb1pp/2nqpn2/1Q1p1p2/1P1P4/P1N1BN2/2P1PPPP/2KR1B1R w q - 3 1';
 
-    expect(isValidFENSyntax(someFEN)).toBe(true);
-    expect(isValidFENSyntax(someFEN2)).toBe(true);
-    expect(isValidFENSyntax(someFEN3)).toBe(true);
-    expect(isValidFENSyntax(someFEN4)).toBe(true);
-    expect(isValidFENSyntax(someFEN5)).toBe(true);
+    expect(isValidFenSyntax(someFEN)).toBe(true);
+    expect(isValidFenSyntax(someFEN2)).toBe(true);
+    expect(isValidFenSyntax(someFEN3)).toBe(true);
+    expect(isValidFenSyntax(someFEN4)).toBe(true);
+    expect(isValidFenSyntax(someFEN5)).toBe(true);
   });
   it('makes a valid FEN return true. wrong color to start with. less P filled up', () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP1P/RNBK2R1 w KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(true);
+    expect(isValidFenSyntax(someFEN)).toBe(true);
   });
 
   //false take
   it('checks corrupted FEN returning true. one dash to much.', () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - -2 1';
-    expect(isValidFENSyntax(someFEN)).toBe(false);
+    expect(isValidFenSyntax(someFEN)).toBe(false);
   });
   it('makes a empty FEN return false.', () => {
-    expect(isValidFENSyntax('')).toBe(false);
+    expect(isValidFenSyntax('')).toBe(false);
   });
   it("makes a corrupted FEN return false. it's one /8 to much.", () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(false);
+    expect(isValidFenSyntax(someFEN)).toBe(false);
   });
   it.skip("makes a corrupted FEN return false. it's one figure to much in row 'b'.", () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR b KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(false);
+    expect(isValidFenSyntax(someFEN)).toBe(false);
   });
   it('one P to much', () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR w KQkq - 0 1';
     const someFEN2: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRRR w KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(false);
-    expect(isValidFENSyntax(someFEN2)).toBe(false);
+    expect(isValidFenSyntax(someFEN)).toBe(false);
+    expect(isValidFenSyntax(someFEN2)).toBe(false);
   });
   //no king should return false
   it('has no kings at all', () => {
     const someFEN: Fen = 'rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQ1BNR w KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(false);
+    expect(isValidFenSyntax(someFEN)).toBe(false);
   });
   it('has two white kings', () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(false);
+    expect(isValidFenSyntax(someFEN)).toBe(false);
   });
   it('has two black kings', () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(false);
+    expect(isValidFenSyntax(someFEN)).toBe(false);
   });
   it('has three kings', () => {
     const someFEN: Fen = 'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
-    expect(isValidFENSyntax(someFEN)).toBe(false);
+    expect(isValidFenSyntax(someFEN)).toBe(false);
   });
 });

--- a/src/__test__/geometry/fen.test.ts
+++ b/src/__test__/geometry/fen.test.ts
@@ -1,27 +1,27 @@
-import { checkValidFEN, INIT_POSITION, FEN } from '../../geometry/fen.ts';
+import { isValidFENSyntax, INIT_POSITION, FEN } from '../../geometry/fen.ts';
 
 describe('regex match for FEN module', () => {
   //true take
   it('checks an init FEN returning true', () => {
-    expect(checkValidFEN(INIT_POSITION)).toBe(true);
+    expect(isValidFENSyntax(INIT_POSITION)).toBe(true);
   });
   it('checks some edited valid FEN returning true. 2 pawns less', () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(true);
+    expect(isValidFENSyntax(someFEN)).toBe(true);
   });
   it('checks some edited valid FEN returning true. edited half moves', () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 2 1';
-    expect(checkValidFEN(someFEN)).toBe(true);
+    expect(isValidFENSyntax(someFEN)).toBe(true);
   });
   it('checks correct FEN with enpassent move to be true', () => {
     const someFEN: FEN =
       'rnbq1rk1/p1p1bppp/5n2/1pPpp3/4P3/3P1N2/PP2BPPP/RNBQ1RK1 w - d6 0 8';
     const someFEN2: FEN =
       'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 3';
-    expect(checkValidFEN(someFEN)).toBe(true);
-    expect(checkValidFEN(someFEN2)).toBe(true);
+    expect(isValidFENSyntax(someFEN)).toBe(true);
+    expect(isValidFENSyntax(someFEN2)).toBe(true);
   });
   it('should pass on vanished or manipulated castling rights. ', () => {
     const someFEN: FEN =
@@ -30,71 +30,70 @@ describe('regex match for FEN module', () => {
       'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w - c6 0 3';
     const someFEN3: FEN =
       'rnbq1rk1/p2p1ppp/1p1bpn2/2p5/4P3/2P2N2/PP3PPP/RNBQKB1R w KQ - 1 7';
- 
+
     const someFEN4: FEN =
-      'r1b1kbnr/ppp2ppp/2nqp3/3p4/3P4/2NQB3/PPP1PPPP/2KR1BNR b kq - 1 5'; 
+      'r1b1kbnr/ppp2ppp/2nqp3/3p4/3P4/2NQB3/PPP1PPPP/2KR1BNR b kq - 1 5';
     const someFEN5: FEN =
       'r3kr2/pppbb1pp/2nqpn2/1Q1p1p2/1P1P4/P1N1BN2/2P1PPPP/2KR1B1R w q - 3 1';
 
-    expect(checkValidFEN(someFEN)).toBe(true);
-    expect(checkValidFEN(someFEN2)).toBe(true);
-    expect(checkValidFEN(someFEN3)).toBe(true);
-    expect(checkValidFEN(someFEN4)).toBe(true);
-    expect(checkValidFEN(someFEN5)).toBe(true);
+    expect(isValidFENSyntax(someFEN)).toBe(true);
+    expect(isValidFENSyntax(someFEN2)).toBe(true);
+    expect(isValidFENSyntax(someFEN3)).toBe(true);
+    expect(isValidFENSyntax(someFEN4)).toBe(true);
+    expect(isValidFENSyntax(someFEN5)).toBe(true);
   });
   it('makes a valid FEN return true. wrong color to start with. less P filled up', () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP1P/RNBK2R1 w KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(true);
+    expect(isValidFENSyntax(someFEN)).toBe(true);
   });
 
   //false take
   it('checks corrupted FEN returning true. one dash to much.', () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - -2 1';
-    expect(checkValidFEN(someFEN)).toBe(false);
+    expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('makes a empty FEN return false.', () => {
-    expect(checkValidFEN('')).toBe(false);
+    expect(isValidFENSyntax('')).toBe(false);
   });
   it("makes a corrupted FEN return false. it's one /8 to much.", () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(false);
+    expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it.skip("makes a corrupted FEN return false. it's one figure to much in row 'b'.", () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR b KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(false);
+    expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('one P to much', () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR w KQkq - 0 1';
     const someFEN2: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRRR w KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(false);
-    expect(checkValidFEN(someFEN2)).toBe(false);
+    expect(isValidFENSyntax(someFEN)).toBe(false);
+    expect(isValidFENSyntax(someFEN2)).toBe(false);
   });
   //no king should return false
   it('has no kings at all', () => {
     const someFEN: FEN =
       'rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQ1BNR w KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(false);
-  }); 
+    expect(isValidFENSyntax(someFEN)).toBe(false);
+  });
   it('has two white kings', () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(false);
+    expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('has two black kings', () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(false);
-  }); 
+    expect(isValidFENSyntax(someFEN)).toBe(false);
+  });
   it('has three kings', () => {
     const someFEN: FEN =
       'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
-    expect(checkValidFEN(someFEN)).toBe(false);
-  }); 
-
+    expect(isValidFENSyntax(someFEN)).toBe(false);
+  });
 });

--- a/src/__test__/geometry/fen.test.ts
+++ b/src/__test__/geometry/fen.test.ts
@@ -1,4 +1,5 @@
-import { isValidFenSyntax, INIT_POSITION } from '../../geometry/fen.ts';
+import { INIT_POSITION } from '../../geometry/constant.ts';
+import { isValidFenSyntax } from '../../geometry/fen.ts';
 import { Fen } from '../../geometry/types.ts';
 
 describe('regex match for Fen module', () => {

--- a/src/__test__/geometry/fen.test.ts
+++ b/src/__test__/geometry/fen.test.ts
@@ -1,4 +1,5 @@
-import { isValidFENSyntax, INIT_POSITION, FEN } from '../../geometry/fen.ts';
+import { isValidFENSyntax, INIT_POSITION } from '../../geometry/fen.ts';
+import { Fen } from '../../geometry/types.ts';
 
 describe('regex match for FEN module', () => {
   //true take
@@ -6,26 +7,26 @@ describe('regex match for FEN module', () => {
     expect(isValidFENSyntax(INIT_POSITION)).toBe(true);
   });
   it('checks some edited valid FEN returning true. 2 pawns less', () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - 0 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(true);
   });
   it('checks some edited valid FEN returning true. edited half moves', () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 2 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 2 1';
     expect(isValidFENSyntax(someFEN)).toBe(true);
   });
   it('checks correct FEN with enpassent move to be true', () => {
-    const someFEN: FEN = 'rnbq1rk1/p1p1bppp/5n2/1pPpp3/4P3/3P1N2/PP2BPPP/RNBQ1RK1 w - d6 0 8';
-    const someFEN2: FEN = 'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 3';
+    const someFEN: Fen = 'rnbq1rk1/p1p1bppp/5n2/1pPpp3/4P3/3P1N2/PP2BPPP/RNBQ1RK1 w - d6 0 8';
+    const someFEN2: Fen = 'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 3';
     expect(isValidFENSyntax(someFEN)).toBe(true);
     expect(isValidFENSyntax(someFEN2)).toBe(true);
   });
   it('should pass on vanished or manipulated castling rights. ', () => {
-    const someFEN: FEN = 'rnbq1rk1/pppp1ppp/3b1n2/4p3/4P3/3P1N2/PPP1BPPP/RNBQ1RK1 b - - 4 5';
-    const someFEN2: FEN = 'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w - c6 0 3';
-    const someFEN3: FEN = 'rnbq1rk1/p2p1ppp/1p1bpn2/2p5/4P3/2P2N2/PP3PPP/RNBQKB1R w KQ - 1 7';
+    const someFEN: Fen = 'rnbq1rk1/pppp1ppp/3b1n2/4p3/4P3/3P1N2/PPP1BPPP/RNBQ1RK1 b - - 4 5';
+    const someFEN2: Fen = 'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w - c6 0 3';
+    const someFEN3: Fen = 'rnbq1rk1/p2p1ppp/1p1bpn2/2p5/4P3/2P2N2/PP3PPP/RNBQKB1R w KQ - 1 7';
 
-    const someFEN4: FEN = 'r1b1kbnr/ppp2ppp/2nqp3/3p4/3P4/2NQB3/PPP1PPPP/2KR1BNR b kq - 1 5';
-    const someFEN5: FEN = 'r3kr2/pppbb1pp/2nqpn2/1Q1p1p2/1P1P4/P1N1BN2/2P1PPPP/2KR1B1R w q - 3 1';
+    const someFEN4: Fen = 'r1b1kbnr/ppp2ppp/2nqp3/3p4/3P4/2NQB3/PPP1PPPP/2KR1BNR b kq - 1 5';
+    const someFEN5: Fen = 'r3kr2/pppbb1pp/2nqpn2/1Q1p1p2/1P1P4/P1N1BN2/2P1PPPP/2KR1B1R w q - 3 1';
 
     expect(isValidFENSyntax(someFEN)).toBe(true);
     expect(isValidFENSyntax(someFEN2)).toBe(true);
@@ -34,47 +35,47 @@ describe('regex match for FEN module', () => {
     expect(isValidFENSyntax(someFEN5)).toBe(true);
   });
   it('makes a valid FEN return true. wrong color to start with. less P filled up', () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP1P/RNBK2R1 w KQkq - 0 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP1P/RNBK2R1 w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(true);
   });
 
   //false take
   it('checks corrupted FEN returning true. one dash to much.', () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - -2 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - -2 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('makes a empty FEN return false.', () => {
     expect(isValidFENSyntax('')).toBe(false);
   });
   it("makes a corrupted FEN return false. it's one /8 to much.", () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it.skip("makes a corrupted FEN return false. it's one figure to much in row 'b'.", () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR b KQkq - 0 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR b KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('one P to much', () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR w KQkq - 0 1';
-    const someFEN2: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRRR w KQkq - 0 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR w KQkq - 0 1';
+    const someFEN2: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRRR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
     expect(isValidFENSyntax(someFEN2)).toBe(false);
   });
   //no king should return false
   it('has no kings at all', () => {
-    const someFEN: FEN = 'rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQ1BNR w KQkq - 0 1';
+    const someFEN: Fen = 'rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQ1BNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('has two white kings', () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('has two black kings', () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('has three kings', () => {
-    const someFEN: FEN = 'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
+    const someFEN: Fen = 'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
 });

--- a/src/__test__/geometry/fen.test.ts
+++ b/src/__test__/geometry/fen.test.ts
@@ -6,35 +6,26 @@ describe('regex match for FEN module', () => {
     expect(isValidFENSyntax(INIT_POSITION)).toBe(true);
   });
   it('checks some edited valid FEN returning true. 2 pawns less', () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - 0 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(true);
   });
   it('checks some edited valid FEN returning true. edited half moves', () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 2 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 2 1';
     expect(isValidFENSyntax(someFEN)).toBe(true);
   });
   it('checks correct FEN with enpassent move to be true', () => {
-    const someFEN: FEN =
-      'rnbq1rk1/p1p1bppp/5n2/1pPpp3/4P3/3P1N2/PP2BPPP/RNBQ1RK1 w - d6 0 8';
-    const someFEN2: FEN =
-      'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 3';
+    const someFEN: FEN = 'rnbq1rk1/p1p1bppp/5n2/1pPpp3/4P3/3P1N2/PP2BPPP/RNBQ1RK1 w - d6 0 8';
+    const someFEN2: FEN = 'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w KQkq c6 0 3';
     expect(isValidFENSyntax(someFEN)).toBe(true);
     expect(isValidFENSyntax(someFEN2)).toBe(true);
   });
   it('should pass on vanished or manipulated castling rights. ', () => {
-    const someFEN: FEN =
-      'rnbq1rk1/pppp1ppp/3b1n2/4p3/4P3/3P1N2/PPP1BPPP/RNBQ1RK1 b - - 4 5';
-    const someFEN2: FEN =
-      'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w - c6 0 3';
-    const someFEN3: FEN =
-      'rnbq1rk1/p2p1ppp/1p1bpn2/2p5/4P3/2P2N2/PP3PPP/RNBQKB1R w KQ - 1 7';
+    const someFEN: FEN = 'rnbq1rk1/pppp1ppp/3b1n2/4p3/4P3/3P1N2/PPP1BPPP/RNBQ1RK1 b - - 4 5';
+    const someFEN2: FEN = 'rnbqkbnr/p2ppppp/1p6/2pP4/8/8/PPP1PPPP/RNBQKBNR w - c6 0 3';
+    const someFEN3: FEN = 'rnbq1rk1/p2p1ppp/1p1bpn2/2p5/4P3/2P2N2/PP3PPP/RNBQKB1R w KQ - 1 7';
 
-    const someFEN4: FEN =
-      'r1b1kbnr/ppp2ppp/2nqp3/3p4/3P4/2NQB3/PPP1PPPP/2KR1BNR b kq - 1 5';
-    const someFEN5: FEN =
-      'r3kr2/pppbb1pp/2nqpn2/1Q1p1p2/1P1P4/P1N1BN2/2P1PPPP/2KR1B1R w q - 3 1';
+    const someFEN4: FEN = 'r1b1kbnr/ppp2ppp/2nqp3/3p4/3P4/2NQB3/PPP1PPPP/2KR1BNR b kq - 1 5';
+    const someFEN5: FEN = 'r3kr2/pppbb1pp/2nqpn2/1Q1p1p2/1P1P4/P1N1BN2/2P1PPPP/2KR1B1R w q - 3 1';
 
     expect(isValidFENSyntax(someFEN)).toBe(true);
     expect(isValidFENSyntax(someFEN2)).toBe(true);
@@ -43,57 +34,47 @@ describe('regex match for FEN module', () => {
     expect(isValidFENSyntax(someFEN5)).toBe(true);
   });
   it('makes a valid FEN return true. wrong color to start with. less P filled up', () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP1P/RNBK2R1 w KQkq - 0 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP1P/RNBK2R1 w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(true);
   });
 
   //false take
   it('checks corrupted FEN returning true. one dash to much.', () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - -2 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPP/RNBQKBNR w KQkq - -2 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('makes a empty FEN return false.', () => {
     expect(isValidFENSyntax('')).toBe(false);
   });
   it("makes a corrupted FEN return false. it's one /8 to much.", () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it.skip("makes a corrupted FEN return false. it's one figure to much in row 'b'.", () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR b KQkq - 0 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR b KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('one P to much', () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR w KQkq - 0 1';
-    const someFEN2: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRRR w KQkq - 0 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPPP/RNBQKBNR w KQkq - 0 1';
+    const someFEN2: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNRRR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
     expect(isValidFENSyntax(someFEN2)).toBe(false);
   });
   //no king should return false
   it('has no kings at all', () => {
-    const someFEN: FEN =
-      'rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQ1BNR w KQkq - 0 1';
+    const someFEN: FEN = 'rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQ1BNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('has two white kings', () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('has two black kings', () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
   it('has three kings', () => {
-    const someFEN: FEN =
-      'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
+    const someFEN: FEN = 'rnbqkbnr/pppppppk/8/8/8/8/PPPPPPPK/RNBQKBNR w KQkq - 0 1';
     expect(isValidFENSyntax(someFEN)).toBe(false);
   });
 });

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -358,7 +358,7 @@ describe('Move generation for king', () => {
       ]),
     );
   });
-  it.only('generates moves for checked king in bishop direction', () => {
+  it('generates moves for checked king in bishop direction', () => {
     const board = createChessBoardFromFen('8/6b1/8/7k/3K4/8/8/8 w - - 0 1');
     const kingIsChecked = isKingChecked(board, 'white');
     const moves = calculateMoveListForKing({ column: 'd', row: 4 }, board, kingIsChecked, false);
@@ -372,6 +372,20 @@ describe('Move generation for king', () => {
 
       //not allowed: e5, c3 (checked by bishop)
     ]);
+  });
+  it('generates moves for checked king in rook direction', () => {
+    const board = createChessBoardFromFen('8/8/8/3R3k/3K4/8/8/8 w - - 0 1');
+    const kingIsChecked = isKingChecked(board, 'black');
+    const moves = calculateMoveListForKing({ column: 'h', row: 5 }, board, kingIsChecked, false);
+    expect(moves).toStrictEqual(
+      expect.arrayContaining([
+        { row: 4, column: 'h', isTaken: false },
+        { row: 6, column: 'h', isTaken: false },
+        { row: 4, column: 'g', isTaken: false },
+        { row: 6, column: 'g', isTaken: false },
+        //not allowed: e5, c3 (checked by bishop)
+      ]),
+    );
   });
 });
 

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -87,6 +87,14 @@ describe('Move generation for pawn', () => {
       { row: 3, column: 'f', isTaken: true },
     ]);
   });
+  it('generates en passent move for black blocked pawn on e4', () => {
+    const initPos = validFenFrom('rnbqkbnr/pppp1ppp/8/8/3Pp3/1P2P3/P1P2PPP/RNBQKBNR b KQkq d3 0 3');
+    const board = createChessBoardFromFen(initPos);
+    const movesE5 = calculateMoveListForPawn({ column: 'e', row: 4 }, board, 'd');
+
+    expect(movesE5).toEqual([{ row: 3, column: 'd', isTaken: true }]);
+  });
+
 });
 
 describe.skip('Move generation for knight', () => {

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -3,6 +3,8 @@ import {
   calculateMoveListForPawn,
   calculateMoveListForKnight,
   calculateMoveListForBishop,
+  calculateMoveListForRook,
+  calculateMoveListForQueen,
 } from '../../geometry/move.ts';
 import { Fen } from '../../geometry/types.ts';
 import { validFenFrom } from '../../geometry/fen.ts';
@@ -218,4 +220,119 @@ describe('Move generation for bishop', () => {
       ]),
     );
   });
+  it('generates empty move for bishop in init position on c1 and f1', () => {
+    const initPos: Fen = INIT_POSITION;
+    const board = createChessBoardFromFen(initPos);
+    const movesC1 = calculateMoveListForBishop({ column: 'c', row: 1 }, board);
+    const movesF1 = calculateMoveListForBishop({ column: 'f', row: 1 }, board);
+    //assert
+    expect(movesC1).toEqual([]);
+    expect(movesF1).toEqual([]);
+  });
 });
+
+describe('Move generation for rook', () => {
+  it('generates all the moves and captures for a rook on h1 (capture queen on g1', () => {
+    const board = createChessBoardFromFen('rn2k2r/1b2bppp/pp2pn2/2p1P1NQ/2P2P2/NP1p2P1/P2P2BP/R1B1K1qR w KQkq - 1 13');
+    const moves = calculateMoveListForRook({ column: 'h', row: 1 }, board);
+    expect(moves).toEqual([{ row: 1, column: 'g', isTaken: true }]);
+  });
+  it('generates all the moves for a rook on a3 (swiss-cross on the rim)', () => {
+    const board = createChessBoardFromFen('8/8/8/8/8/R7/8/5K1k w - - 0 1');
+    const moves = calculateMoveListForRook({ column: 'a', row: 3 }, board);
+    expect(moves).toEqual(
+      expect.arrayContaining([
+        { row: 3, column: 'b', isTaken: false },
+        { row: 3, column: 'c', isTaken: false },
+        { row: 3, column: 'd', isTaken: false },
+        { row: 3, column: 'e', isTaken: false },
+        { row: 3, column: 'f', isTaken: false },
+        { row: 3, column: 'g', isTaken: false },
+        { row: 3, column: 'h', isTaken: false },
+
+        { row: 4, column: 'a', isTaken: false },
+        { row: 5, column: 'a', isTaken: false },
+        { row: 6, column: 'a', isTaken: false },
+        { row: 7, column: 'a', isTaken: false },
+        { row: 8, column: 'a', isTaken: false },
+
+        { row: 2, column: 'a', isTaken: false },
+        { row: 1, column: 'a', isTaken: false },
+      ]),
+    );
+  });
+  it('generates all the moves for a rook on d5', () => {
+    const board = createChessBoardFromFen('8/8/8/3R4/8/8/5K1k/8 w - - 0 1');
+    const moves = calculateMoveListForRook({ column: 'd', row: 5 }, board);
+    expect(moves).toEqual(
+      expect.arrayContaining([
+        //on row 5
+        { row: 5, column: 'a', isTaken: false },
+        { row: 5, column: 'b', isTaken: false },
+        { row: 5, column: 'c', isTaken: false },
+
+        { row: 5, column: 'e', isTaken: false },
+        { row: 5, column: 'f', isTaken: false },
+        { row: 5, column: 'g', isTaken: false },
+        { row: 5, column: 'h', isTaken: false },
+        //on column d
+        { row: 6, column: 'd', isTaken: false },
+        { row: 7, column: 'd', isTaken: false },
+        { row: 8, column: 'd', isTaken: false },
+
+        { row: 4, column: 'd', isTaken: false },
+        { row: 3, column: 'd', isTaken: false },
+        { row: 2, column: 'd', isTaken: false },
+        { row: 1, column: 'd', isTaken: false },
+      ]),
+    );
+  });
+});
+
+describe('Move generation for Queen', () => {
+  it('generates all the moves and captures for a queen on d5 (star)', () => {
+    const board = createChessBoardFromFen('8/8/8/3Q4/8/8/5K1k/8 w - - 0 1');
+    const moves = calculateMoveListForQueen({ column: 'd', row: 5 }, board);
+
+    expect(moves).toEqual(
+      expect.arrayContaining([
+        //on row 5
+        { row: 5, column: 'a', isTaken: false },
+        { row: 5, column: 'b', isTaken: false },
+        { row: 5, column: 'c', isTaken: false },
+
+        { row: 5, column: 'e', isTaken: false },
+        { row: 5, column: 'f', isTaken: false },
+        { row: 5, column: 'g', isTaken: false },
+        { row: 5, column: 'h', isTaken: false },
+        //on column d
+        { row: 6, column: 'd', isTaken: false },
+        { row: 7, column: 'd', isTaken: false },
+        { row: 8, column: 'd', isTaken: false },
+
+        { row: 4, column: 'd', isTaken: false },
+        { row: 3, column: 'd', isTaken: false },
+        { row: 2, column: 'd', isTaken: false },
+        { row: 1, column: 'd', isTaken: false },
+
+        //on diagonal
+        { row: 6, column: 'e', isTaken: false },
+        { row: 7, column: 'f', isTaken: false },
+        { row: 8, column: 'g', isTaken: false },
+
+        { row: 4, column: 'c', isTaken: false },
+        { row: 3, column: 'b', isTaken: false },
+        { row: 2, column: 'a', isTaken: false },
+
+        { row: 6, column: 'c', isTaken: false },
+        { row: 7, column: 'b', isTaken: false },
+        { row: 8, column: 'a', isTaken: false },
+
+        { row: 4, column: 'e', isTaken: false },
+        { row: 3, column: 'f', isTaken: false },
+        { row: 2, column: 'g', isTaken: false },
+        { row: 1, column: 'h', isTaken: false },
+      ]),
+    );
+  });
+}); 

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -3,7 +3,7 @@ import { calculateMoveListForPawn } from '../../geometry/move.ts';
 import { Fen } from '../../geometry/types.ts';
 import { createChessBoardFromFen } from '../../geometry/board.ts';
 describe('Move generation for pawn', () => {
-  it.skip('generates all the moves for an e2 pawn in init position', () => {
+  it('generates all the moves for an e2 pawn in init position', () => {
     const initPos: Fen = INIT_POSITION;
     const board = createChessBoardFromFen(initPos);
     const moves = calculateMoveListForPawn({ row: 2, column: 'e' }, board);

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -1,0 +1,15 @@
+import { INIT_POSITION } from '../../geometry/fen.ts';
+import { calculateMoveListForPawn } from '../../geometry/move.ts';
+import { Fen } from '../../geometry/types.ts';
+import { createChessBoardFromFen } from '../../geometry/board.ts';
+describe('Move generation for pawn', () => {
+  it.skip('generates all the moves for an e2 pawn in init position', () => {
+    const initPos: Fen = INIT_POSITION;
+    const board = createChessBoardFromFen(initPos);
+    const moves = calculateMoveListForPawn({ row: 2, column: 'e' }, board);
+    expect(moves).toEqual([
+      { row: 3, column: 'e' },
+      { row: 4, column: 'e' },
+    ]);
+  });
+});

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -3,7 +3,7 @@ import { calculateMoveListForPawn } from '../../geometry/move.ts';
 import { Fen } from '../../geometry/types.ts';
 import { createChessBoardFromFen } from '../../geometry/board.ts';
 describe('Move generation for pawn', () => {
-  it('generates all the moves for an e2 pawn in init position', () => {
+  it.skip('generates all the moves for an e2 pawn in init position', () => {
     const initPos: Fen = INIT_POSITION;
     const board = createChessBoardFromFen(initPos);
     const moves = calculateMoveListForPawn({ row: 2, column: 'e' }, board);

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -51,4 +51,44 @@ describe('Move generation for pawn', () => {
     expect(movesL).toEqual([]);
     expect(movesB4).toEqual([]);
   });
+
+  it('generates capture moves for white pawn on f4 and black pawn on e5', () => {
+    const initPos = validFenFrom('rnbqkbnr/pp1p1ppp/8/2p1p3/3P1P2/8/PPP1P1PP/RNBQKBNR w KQkq c6 0 3');
+    const board = createChessBoardFromFen(initPos);
+    const movesWhitePawn = calculateMoveListForPawn({ column: 'f', row: 4 }, board);
+    const movesBlackPawn = calculateMoveListForPawn({ column: 'e', row: 5 }, board);
+    expect(movesWhitePawn).toEqual([
+      { row: 5, column: 'f', isTaken: false },
+      { row: 5, column: 'e', isTaken: true },
+    ]);
+    expect(movesBlackPawn).toEqual([
+      { row: 4, column: 'e', isTaken: false },
+      { row: 4, column: 'f', isTaken: true },
+      { row: 4, column: 'd', isTaken: true },
+    ]);
+  });
+
+  it('generates en passant move for white pawn on e5', () => {
+    const initPos = validFenFrom('rnbqkbnr/p1p1pppp/8/1p1pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3');
+    const board = createChessBoardFromFen(initPos);
+    const movesE5 = calculateMoveListForPawn({ column: 'e', row: 5 }, board, 'd');
+    expect(movesE5).toEqual([
+      { row: 6, column: 'e', isTaken: false },
+      { row: 6, column: 'd', isTaken: true },
+    ]);
+  });
+  it('generates en passant move for black pawn on e4', () => {
+    const initPos = validFenFrom('rnbqkbnr/pppp1ppp/8/8/4pP2/1P6/PBPPP1PP/RN1QKBNR b KQkq f3 0 3');
+    const board = createChessBoardFromFen(initPos);
+    const movesE5 = calculateMoveListForPawn({ column: 'e', row: 4 }, board, 'f');
+
+    expect(movesE5).toEqual([
+      { row: 3, column: 'e', isTaken: false },
+      { row: 3, column: 'f', isTaken: true },
+    ]);
+  });
+});
+
+describe.skip('Move generation for knight', () => {
+  //to do
 });

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -220,7 +220,7 @@ describe('Move generation for bishop', () => {
       ]),
     );
   });
-  it('generates empty move for bishop in init position on c1 and f1', () => {
+  it('generates empty move lists for bishop in init position on c1 and f1', () => {
     const initPos: Fen = INIT_POSITION;
     const board = createChessBoardFromFen(initPos);
     const movesC1 = calculateMoveListForBishop({ column: 'c', row: 1 }, board);
@@ -332,6 +332,47 @@ describe('Move generation for queen', () => {
         { row: 3, column: 'f', isTaken: false },
         { row: 2, column: 'g', isTaken: false },
         { row: 1, column: 'h', isTaken: false },
+      ]),
+    );
+  });
+  it('generates all moves for a queen on d3 hitting a king on h7.. h7 should not be included..', () => {
+    const board = createChessBoardFromFen('8/7k/8/8/8/3Q4/5K2/8 w - - 0 1');
+    const moves = calculateMoveListForQueen({ column: 'd', row: 3 }, board);
+    expect(moves).toEqual(
+      expect.arrayContaining([
+        //on row 3
+        { row: 3, column: 'a', isTaken: false },
+        { row: 3, column: 'b', isTaken: false },
+        { row: 3, column: 'c', isTaken: false },
+
+        { row: 3, column: 'e', isTaken: false },
+        { row: 3, column: 'f', isTaken: false },
+        { row: 3, column: 'g', isTaken: false },
+        { row: 3, column: 'h', isTaken: false },
+        //on column d
+        { row: 4, column: 'd', isTaken: false },
+        { row: 5, column: 'd', isTaken: false },
+        { row: 6, column: 'd', isTaken: false },
+        { row: 7, column: 'd', isTaken: false },
+        { row: 8, column: 'd', isTaken: false },
+
+        { row: 2, column: 'd', isTaken: false },
+        { row: 1, column: 'd', isTaken: false },
+
+        //on diagonal
+        { row: 4, column: 'e', isTaken: false },
+        { row: 5, column: 'f', isTaken: false },
+        { row: 6, column: 'g', isTaken: false },
+
+        { row: 2, column: 'c', isTaken: false },
+        { row: 1, column: 'b', isTaken: false },
+
+        { row: 4, column: 'c', isTaken: false },
+        { row: 5, column: 'b', isTaken: false },
+        { row: 6, column: 'a', isTaken: false },
+
+        { row: 2, column: 'e', isTaken: false },
+        { row: 1, column: 'f', isTaken: false },
       ]),
     );
   });

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -289,7 +289,7 @@ describe('Move generation for rook', () => {
   });
 });
 
-describe('Move generation for Queen', () => {
+describe('Move generation for queen', () => {
   it('generates all the moves and captures for a queen on d5 (star)', () => {
     const board = createChessBoardFromFen('8/8/8/3Q4/8/8/5K1k/8 w - - 0 1');
     const moves = calculateMoveListForQueen({ column: 'd', row: 5 }, board);
@@ -336,3 +336,4 @@ describe('Move generation for Queen', () => {
     );
   });
 }); 
+

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -5,6 +5,7 @@ import {
   calculateMoveListForBishop,
   calculateMoveListForRook,
   calculateMoveListForQueen,
+  calculateMoveListForPiece,
 } from '../../geometry/move.ts';
 import { Fen } from '../../geometry/types.ts';
 import { validFenFrom } from '../../geometry/fen.ts';
@@ -232,7 +233,7 @@ describe('Move generation for bishop', () => {
 });
 
 describe('Move generation for rook', () => {
-  it('generates all the moves and captures for a rook on h1 (capture queen on g1', () => {
+  it('generates all the moves and captures for a rook on h1 (capture queen on g1)', () => {
     const board = createChessBoardFromFen('rn2k2r/1b2bppp/pp2pn2/2p1P1NQ/2P2P2/NP1p2P1/P2P2BP/R1B1K1qR w KQkq - 1 13');
     const moves = calculateMoveListForRook({ column: 'h', row: 1 }, board);
     expect(moves).toEqual([{ row: 1, column: 'g', isTaken: true }]);
@@ -335,6 +336,24 @@ describe('Move generation for queen', () => {
       ]),
     );
   });
+  //all other queen tests are covered by rook and bishop tests
+});
 
+describe('Move generation for king', () => {});
+
+describe('calculates moves for arbitrary peace', () => {
+  it('returns an empty move list if king is checked by pawn', () => {
+    const initPos = validFenFrom('8/8/8/4pP2/3K4/8/6k1/8 w - - 0 1');
+    const board = createChessBoardFromFen(initPos);
+    const movesE1 = calculateMoveListForPiece({ column: 'f', row: 5 }, board);
+    //movelist checked king
+    expect(movesE1).toEqual([]);
+  });
+  it('returns an empty move list if king is checked by knight', () => {
+    const initPos = validFenFrom('8/8/2n1p3/5P2/3K4/8/6k1/8 w - - 0 1');
+    const board = createChessBoardFromFen(initPos);
+    const movesE1 = calculateMoveListForPiece({ column: 'f', row: 5 }, board);
+    expect(movesE1).toEqual([]);
+  });
+  //other tests not necessarily needed, as they are covered by check.test.ts
 }); 
-

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -67,6 +67,16 @@ describe('Move generation for pawn', () => {
       { row: 4, column: 'd', isTaken: true },
     ]);
   });
+  it('generates capture moves for white pawn on c2', () => {
+    const initPos = validFenFrom('rnbqkbnr/pppp1ppp/8/8/8/1P1pP3/P1P2PPP/RNBQKBNR w KQkq - 0 4');
+    const board = createChessBoardFromFen(initPos);
+    const movesC2 = calculateMoveListForPawn({ column: 'c', row: 2 }, board);
+    expect(movesC2).toEqual([
+      { row: 3, column: 'c', isTaken: false },
+      { row: 3, column: 'd', isTaken: true },
+      { row: 4, column: 'c', isTaken: false },
+    ]);
+  });
 
   it('generates en passant move for white pawn on e5', () => {
     const initPos = validFenFrom('rnbqkbnr/p1p1pppp/8/1p1pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3');

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -38,10 +38,17 @@ describe('Move generation for pawn', () => {
     expect(movesE4).toEqual([]);
     expect(movesH4).toEqual([]);
   });
-  it('generates an empty list for a blocked black pawn on f7', () => {
+  it('generates an empty list for a blocked black pawn on f7 and b4', () => {
     const initPosL: Fen = validFenFrom('rnbqkb1r/1p1p1ppp/p1p2P2/8/3P4/8/PP3PPP/RNBQKBNR b KQkq - 0 6');
+    const initPosB4: Fen = validFenFrom('rnbqkbnr/p1p2pp1/8/3pp2p/1p1P1B1P/1P2P3/P1P2PP1/RN1QKBNR w KQkq - 0 6');
+
     const boardL = createChessBoardFromFen(initPosL);
+    const boardB4 = createChessBoardFromFen(initPosB4);
+
     const movesL = calculateMoveListForPawn({ column: 'f', row: 7 }, boardL);
+    const movesB4 = calculateMoveListForPawn({ column: 'b', row: 4 }, boardB4);
+
     expect(movesL).toEqual([]);
+    expect(movesB4).toEqual([]);
   });
 });

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -335,46 +335,6 @@ describe('Move generation for queen', () => {
       ]),
     );
   });
-  it('generates all moves for a queen on d3 hitting a king on h7.. h7 should not be included..', () => {
-    const board = createChessBoardFromFen('8/7k/8/8/8/3Q4/5K2/8 w - - 0 1');
-    const moves = calculateMoveListForQueen({ column: 'd', row: 3 }, board);
-    expect(moves).toEqual(
-      expect.arrayContaining([
-        //on row 3
-        { row: 3, column: 'a', isTaken: false },
-        { row: 3, column: 'b', isTaken: false },
-        { row: 3, column: 'c', isTaken: false },
 
-        { row: 3, column: 'e', isTaken: false },
-        { row: 3, column: 'f', isTaken: false },
-        { row: 3, column: 'g', isTaken: false },
-        { row: 3, column: 'h', isTaken: false },
-        //on column d
-        { row: 4, column: 'd', isTaken: false },
-        { row: 5, column: 'd', isTaken: false },
-        { row: 6, column: 'd', isTaken: false },
-        { row: 7, column: 'd', isTaken: false },
-        { row: 8, column: 'd', isTaken: false },
-
-        { row: 2, column: 'd', isTaken: false },
-        { row: 1, column: 'd', isTaken: false },
-
-        //on diagonal
-        { row: 4, column: 'e', isTaken: false },
-        { row: 5, column: 'f', isTaken: false },
-        { row: 6, column: 'g', isTaken: false },
-
-        { row: 2, column: 'c', isTaken: false },
-        { row: 1, column: 'b', isTaken: false },
-
-        { row: 4, column: 'c', isTaken: false },
-        { row: 5, column: 'b', isTaken: false },
-        { row: 6, column: 'a', isTaken: false },
-
-        { row: 2, column: 'e', isTaken: false },
-        { row: 1, column: 'f', isTaken: false },
-      ]),
-    );
-  });
 }); 
 

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -1,5 +1,5 @@
 import { INIT_POSITION } from '../../geometry/constant.ts';
-import { calculateMoveListForPawn } from '../../geometry/move.ts';
+import { calculateMoveListForPawn, calculateMoveListForKnight } from '../../geometry/move.ts';
 import { Fen } from '../../geometry/types.ts';
 import { validFenFrom } from '../../geometry/fen.ts';
 import { createChessBoardFromFen } from '../../geometry/board.ts';
@@ -104,9 +104,55 @@ describe('Move generation for pawn', () => {
 
     expect(movesE5).toEqual([{ row: 3, column: 'd', isTaken: true }]);
   });
-
+  it('generates en passent move for black pawn on d4 with capture', () => {
+    const initPos = validFenFrom('rnbqkbnr/ppp1pppp/8/8/2Pp4/4PN2/PP1P1PPP/RNBQKB1R b KQkq c3 0 3');
+    const board = createChessBoardFromFen(initPos);
+    const movesD4 = calculateMoveListForPawn({ column: 'd', row: 4 }, board, 'c');
+    expect(movesD4).toEqual([
+      { row: 3, column: 'd', isTaken: false },
+      { row: 3, column: 'e', isTaken: true },
+      { row: 3, column: 'c', isTaken: true },
+    ]);
+  });
 });
 
-describe.skip('Move generation for knight', () => {
-  //to do
+describe('Move generation for knight', () => {
+  it('generates all the moves and captures for white knight on f3.', () => {
+    const initPos: Fen = 'rnbqkbnr/ppp2ppp/4p3/8/2Pp4/4PN2/PP1P1PPP/RNBQKB1R w KQkq - 0 4';
+    const board = createChessBoardFromFen(initPos);
+    const movesF3 = calculateMoveListForKnight({ column: 'f', row: 3 }, board);
+    expect(movesF3).toEqual([
+      { row: 5, column: 'g', isTaken: false },
+      { row: 5, column: 'e', isTaken: false },
+      { row: 1, column: 'g', isTaken: false },
+      { row: 4, column: 'h', isTaken: false },
+      { row: 4, column: 'd', isTaken: true },
+    ]);
+  });
+  it('generate all the moves and captures for a black knight on f6', () => {
+    const initPos = 'rnbqkb1r/ppp2ppp/4pn2/6NQ/2P1P3/3p4/PP1P1PPP/RNB1KB1R b KQkq - 1 6';
+    const board = createChessBoardFromFen(initPos);
+    const movesF3 = calculateMoveListForKnight({ column: 'f', row: 6 }, board);
+    expect(movesF3).toEqual(
+      expect.arrayContaining([
+        { row: 5, column: 'h', isTaken: true },
+        { row: 8, column: 'g', isTaken: false },
+        { row: 7, column: 'd', isTaken: false },
+        { row: 5, column: 'd', isTaken: false },
+        { row: 4, column: 'g', isTaken: false },
+        { row: 4, column: 'e', isTaken: true },
+      ]),
+    );
+  });
+  it('generates all the moves for a knight on a3 (on the rim)', () => {
+    const initPos = 'rnbqkb1r/1pp2ppp/p3pn2/6NQ/2P1P3/N2p4/PP1P1PPP/R1B1KB1R b KQkq - 1 7';
+    const board = createChessBoardFromFen(initPos);
+    const movesA3 = calculateMoveListForKnight({ column: 'a', row: 3 }, board);
+    expect(movesA3).toEqual(
+      expect.arrayContaining([
+        { row: 5, column: 'b', isTaken: false },
+        { row: 2, column: 'c', isTaken: false },
+      ]),
+    );
+  });
 });

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -1,5 +1,9 @@
 import { INIT_POSITION } from '../../geometry/constant.ts';
-import { calculateMoveListForPawn, calculateMoveListForKnight } from '../../geometry/move.ts';
+import {
+  calculateMoveListForPawn,
+  calculateMoveListForKnight,
+  calculateMoveListForBishop,
+} from '../../geometry/move.ts';
 import { Fen } from '../../geometry/types.ts';
 import { validFenFrom } from '../../geometry/fen.ts';
 import { createChessBoardFromFen } from '../../geometry/board.ts';
@@ -152,6 +156,65 @@ describe('Move generation for knight', () => {
       expect.arrayContaining([
         { row: 5, column: 'b', isTaken: false },
         { row: 2, column: 'c', isTaken: false },
+      ]),
+    );
+  });
+});
+
+describe('Move generation for bishop', () => {
+  //to be implemented
+  it('generates all the moves and captures for a bishop on f1', () => {
+    const initPos = validFenFrom('rnbqkb1r/1pp2ppp/p3pn2/6NQ/2P1P3/N2p4/PP1P1PPP/R1B1KB1R b KQkq - 1 7');
+    const board = createChessBoardFromFen(initPos);
+    const moves = calculateMoveListForBishop({ column: 'f', row: 1 }, board);
+    expect(moves).toEqual([
+      { row: 2, column: 'e', isTaken: false },
+      { row: 3, column: 'd', isTaken: true },
+    ]);
+  });
+  it('generates all the moves for white bishop on g2, which targets the diagonal a8-h1', () => {
+    const initPos = validFenFrom('rnbqk2r/4bppp/pp2pn2/2p1P1NQ/2P5/N2p2P1/PP1P1PBP/R1B1K2R b KQkq - 2 10');
+    const board = createChessBoardFromFen(initPos);
+    const moves = calculateMoveListForBishop({ column: 'g', row: 2 }, board);
+    expect(moves).toEqual(
+      expect.arrayContaining([
+        { row: 3, column: 'f', isTaken: false },
+        { row: 4, column: 'e', isTaken: false },
+        { row: 5, column: 'd', isTaken: false },
+        { row: 6, column: 'c', isTaken: false },
+        { row: 7, column: 'b', isTaken: false },
+        { row: 8, column: 'a', isTaken: true },
+
+        { row: 3, column: 'h', isTaken: false },
+        { row: 1, column: 'f', isTaken: false },
+      ]),
+    );
+    expect(moves).not.toEqual(
+      expect.arrayContaining([
+        { row: 3, column: 'f', isTaken: false },
+        { row: 4, column: 'e', isTaken: false },
+        { row: 5, column: 'd', isTaken: false },
+        { row: 6, column: 'c', isTaken: false },
+        { row: 7, column: 'b', isTaken: false },
+        { row: 8, column: 'a', isTaken: false },
+
+        { row: 3, column: 'h', isTaken: false },
+        { row: 1, column: 'f', isTaken: false },
+      ]),
+    );
+  });
+  it('generates all the moves for black bishop on b7, which targets the diagonal a8-h1', () => {
+    const initPos = validFenFrom('rn2k2r/1b2bppp/pp2pn2/2p1P1NQ/2Pq1P2/NP1p2P1/P2P2BP/R1B1K2R b KQkq f3 0 12');
+    const board = createChessBoardFromFen(initPos);
+    const moves = calculateMoveListForBishop({ column: 'b', row: 7 }, board);
+    expect(moves).toEqual(
+      expect.arrayContaining([
+        { row: 8, column: 'c', isTaken: false },
+        { row: 6, column: 'c', isTaken: false },
+        { row: 5, column: 'd', isTaken: false },
+        { row: 4, column: 'e', isTaken: false },
+        { row: 3, column: 'f', isTaken: false },
+        { row: 2, column: 'g', isTaken: true },
       ]),
     );
   });

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -481,6 +481,29 @@ describe('Move generation for king', () => {
     const movesE1 = calculateMoveListForKing({ column: 'e', row: 1 }, board, false, true);
     expect(movesE1).toEqual([{ row: 2, column: 'd', isTaken: false }]); // only move is d2
   }); 
+  it('validate black king-side castle move not possible in position', () => {
+    const board = createChessBoardFromFen('rn1Rk2r/ppB1p1pp/2p1p1n1/8/8/N1Q1P1r1/PP2PPb1/R3K2R w kq - 0 1');
+    const board2 = createChessBoardFromFen('rn1Rk2r/ppB1pPpp/2p1p1n1/8/8/N1Q1P1r1/PP3Pb1/R3K2R w kq - 0 1');
+    const movesE8 = calculateMoveListForKing({ column: 'e', row: 8 }, board, false, true);
+    const movesE82 = calculateMoveListForKing({ column: 'e', row: 8 }, board2, false, true);
+
+    expect(movesE8).toEqual([{ row: 7, column: 'f', isTaken: false }]); //castle not possible
+    expect(movesE82).toEqual([{ row: 7, column: 'f', isTaken: true }]); //castle not possible
+  });
+  it('validate white side castle move not possible in position', () => {
+    const board = createChessBoardFromFen('rn2k2r/ppB1p1pp/2pRpPn1/8/8/N1Q1P1r1/PP3P2/R2K3R w kq - 0 1');
+    const movesE8 = calculateMoveListForKing({ column: 'd', row: 1 }, board, false, true);
+    expect(movesE8).toEqual(
+      expect.arrayContaining([
+        { row: 1, column: 'c', isTaken: false },
+        { row: 2, column: 'c', isTaken: false },
+        { row: 2, column: 'd', isTaken: false },
+        { row: 1, column: 'e', isTaken: false },
+        { row: 2, column: 'e', isTaken: false },
+      ]),
+    ); // only move is d7
+  }); 
+
 });
 
 describe('calculates moves for arbitrary peace', () => {

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -1,15 +1,47 @@
-import { INIT_POSITION } from '../../geometry/fen.ts';
+import { INIT_POSITION } from '../../geometry/constant.ts';
 import { calculateMoveListForPawn } from '../../geometry/move.ts';
 import { Fen } from '../../geometry/types.ts';
+import { validFenFrom } from '../../geometry/fen.ts';
 import { createChessBoardFromFen } from '../../geometry/board.ts';
+
 describe('Move generation for pawn', () => {
-  it.skip('generates all the moves for an e2 pawn in init position', () => {
+  it('generates all the moves for an e2, a2, h2 pawn in init position', () => {
     const initPos: Fen = INIT_POSITION;
     const board = createChessBoardFromFen(initPos);
-    const moves = calculateMoveListForPawn({ row: 2, column: 'e' }, board);
-    expect(moves).toEqual([
-      { row: 3, column: 'e' },
-      { row: 4, column: 'e' },
+    const movesE2 = calculateMoveListForPawn({ column: 'e', row: 2 }, board);
+    const movesA2 = calculateMoveListForPawn({ column: 'a', row: 2 }, board);
+    const movesH2 = calculateMoveListForPawn({ column: 'h', row: 2 }, board);
+
+    expect(movesE2).toEqual([
+      { row: 3, column: 'e', isTaken: false },
+      { row: 4, column: 'e', isTaken: false },
     ]);
+    expect(movesA2).toEqual([
+      { row: 3, column: 'a', isTaken: false },
+      { row: 4, column: 'a', isTaken: false },
+    ]);
+    expect(movesH2).toEqual([
+      { row: 3, column: 'h', isTaken: false },
+      { row: 4, column: 'h', isTaken: false },
+    ]);
+  });
+  it('generates an empty list for a blocked white pawn on e4 and h4', () => {
+    const initPosE4: Fen = validFenFrom('rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2');
+    const initPosH4: Fen = validFenFrom('rnbqkbnr/ppppppp1/8/7p/7P/8/PPPPPPP1/RNBQKBNR w KQkq h6 0 2');
+
+    const boardE4 = createChessBoardFromFen(initPosE4);
+    const boardH4 = createChessBoardFromFen(initPosH4);
+
+    const movesE4 = calculateMoveListForPawn({ column: 'e', row: 4 }, boardE4);
+    const movesH4 = calculateMoveListForPawn({ column: 'h', row: 4 }, boardH4);
+
+    expect(movesE4).toEqual([]);
+    expect(movesH4).toEqual([]);
+  });
+  it('generates an empty list for a blocked black pawn on f7', () => {
+    const initPosL: Fen = validFenFrom('rnbqkb1r/1p1p1ppp/p1p2P2/8/3P4/8/PP3PPP/RNBQKBNR b KQkq - 0 6');
+    const boardL = createChessBoardFromFen(initPosL);
+    const movesL = calculateMoveListForPawn({ column: 'f', row: 7 }, boardL);
+    expect(movesL).toEqual([]);
   });
 });

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -476,6 +476,11 @@ describe('Move generation for king', () => {
       { row: 2, column: 'f', isTaken: true },
     ]);
   });
+  it('validate white queen-side castle move not possible in position', () => {
+    const board = createChessBoardFromFen('rn1qk2r/pppppppp/6n1/8/8/N1Q1P3/PP2PPb1/R3Kr1R w kq - 0 1');
+    const movesE1 = calculateMoveListForKing({ column: 'e', row: 1 }, board, false, true);
+    expect(movesE1).toEqual([{ row: 2, column: 'd', isTaken: false }]); // only move is d2
+  }); 
 });
 
 describe('calculates moves for arbitrary peace', () => {

--- a/src/__test__/geometry/move.test.ts
+++ b/src/__test__/geometry/move.test.ts
@@ -6,10 +6,12 @@ import {
   calculateMoveListForRook,
   calculateMoveListForQueen,
   calculateMoveListForPiece,
+  calculateMoveListForKing,
 } from '../../geometry/move.ts';
 import { Fen } from '../../geometry/types.ts';
 import { validFenFrom } from '../../geometry/fen.ts';
 import { createChessBoardFromFen } from '../../geometry/board.ts';
+import { isKingChecked } from '../../geometry/check.ts';
 
 describe('Move generation for pawn', () => {
   it('generates all the moves for an e2, a2, h2 pawn in init position', () => {
@@ -339,7 +341,39 @@ describe('Move generation for queen', () => {
   //all other queen tests are covered by rook and bishop tests
 });
 
-describe('Move generation for king', () => {});
+describe('Move generation for king', () => {
+  it('generates all the moves for a king on d4', () => {
+    const board = createChessBoardFromFen('8/8/8/7k/3K4/8/8/8 w - - 0 1');
+    const moves = calculateMoveListForKing({ column: 'd', row: 4 }, board, false, false);
+    expect(moves).toEqual(
+      expect.arrayContaining([
+        { row: 5, column: 'c', isTaken: false },
+        { row: 5, column: 'd', isTaken: false },
+        { row: 5, column: 'e', isTaken: false },
+        { row: 4, column: 'e', isTaken: false },
+        { row: 4, column: 'c', isTaken: false },
+        { row: 3, column: 'e', isTaken: false },
+        { row: 3, column: 'd', isTaken: false },
+        { row: 3, column: 'c', isTaken: false },
+      ]),
+    );
+  });
+  it.only('generates moves for checked king in bishop direction', () => {
+    const board = createChessBoardFromFen('8/6b1/8/7k/3K4/8/8/8 w - - 0 1');
+    const kingIsChecked = isKingChecked(board, 'white');
+    const moves = calculateMoveListForKing({ column: 'd', row: 4 }, board, kingIsChecked, false);
+    expect(moves).toStrictEqual([
+      { row: 5, column: 'd', isTaken: false },
+      { row: 3, column: 'd', isTaken: false },
+      { row: 4, column: 'e', isTaken: false },
+      { row: 4, column: 'c', isTaken: false },
+      { row: 5, column: 'c', isTaken: false },
+      { row: 3, column: 'e', isTaken: false },
+
+      //not allowed: e5, c3 (checked by bishop)
+    ]);
+  });
+});
 
 describe('calculates moves for arbitrary peace', () => {
   it('returns an empty move list if king is checked by pawn', () => {

--- a/src/__test__/stub/sum.test.ts
+++ b/src/__test__/stub/sum.test.ts
@@ -1,7 +1,0 @@
-import { sum } from './sum.ts';
-
-describe('sum function is working', () => {
-  it('shows that sum(2,2) is 4.', () => {
-    expect(sum(2, 2)).toBe(4);
-  });
-});

--- a/src/__test__/stub/sum.ts
+++ b/src/__test__/stub/sum.ts
@@ -1,1 +1,0 @@
-export const sum = (a: number, b: number) => a + b;

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -61,8 +61,7 @@ export const boardToPieceMap = (board: Board): (Piece | null)[][] => {
   return boardMap;
 };
 
-export const boardToColorMap = (board: Board): BoardColorMap =>
-  boardToPieceMap(board).map((row) => row.map((piece) => (isNil(piece) ? 'none' : piece.color)));
+export const boardToColorMap = (board: Board): BoardColorMap => boardPieceMapToColorMap(boardToPieceMap(board));
 
 export const getPieceFromPieceMap = (boardMap: (Piece | null)[][], position: Position): Piece | null => {
   const row = rowToIndex(position.row) - 1;
@@ -73,4 +72,5 @@ export const getPieceFromPieceMap = (boardMap: (Piece | null)[][], position: Pos
   return null;
 };
 
-
+export const boardPieceMapToColorMap = (boardPieceMap: BoardPieceMap): BoardColorMap =>
+  boardPieceMap.map((row) => row.map((piece) => (isNil(piece) ? 'none' : piece.color)));

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -1,6 +1,19 @@
 import { isValidFEN } from './fen.ts';
 import { isNil, isNotNil } from './helper.ts';
-import { FEN, Board, FigureLetter, Row, Column, Position, BoardColorMap, Color, Piece, CX, CY } from './types.ts';
+import {
+  Fen,
+  Board,
+  FigureLetter,
+  Row,
+  Column,
+  Position,
+  BoardColorMap,
+  Color,
+  Piece,
+  CX,
+  CY,
+  Columns,
+} from './types.ts';
 import { rowToIndex, columnToIndex, coordinateToPosition, letterToFigure, figureToLetter } from './transform.ts';
 
 export const positionToCoordinate = (position: Position): [CY, CX] => [
@@ -11,20 +24,20 @@ const stringToPosition = (pos: string): Position => {
   if (pos.length !== 2) throw new Error('Invalid position string');
   const col = pos.charAt(0) as Column;
   const row = parseInt(pos.charAt(1), 10) as Row;
-  if (!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].includes(col) || isNaN(row) || row < 1 || row > 8) {
+  if (!Columns.includes(col) || isNaN(row) || row < 1 || row > 8) {
     throw new Error('Invalid position string');
   }
   return { column: col, row: row };
 };
 
-export const createChessBoardFromFEN = (fen: FEN): Board => {
-  if (!isValidFEN(fen)) throw new Error('Invalid FEN string');
+export const createChessBoardFromFEN = (fen: Fen): Board => {
+  if (!isValidFEN(fen)) throw new Error('Invalid Fen string');
 
   const [piecePlacement] = fen.split(' ');
-  if (isNil(piecePlacement)) throw new Error('Invalid FEN string. No piece placement');
+  if (isNil(piecePlacement)) throw new Error('Invalid Fen string. No piece placement');
 
   const rows = piecePlacement?.split('/');
-  if (rows?.length !== 8) throw new Error('Invalid FEN string. Not 8 rows');
+  if (rows?.length !== 8) throw new Error('Invalid Fen string. Not 8 rows');
 
   const board: Board = [];
 
@@ -33,7 +46,7 @@ export const createChessBoardFromFEN = (fen: FEN): Board => {
     for (const char of row) {
       if (/\d/.test(char)) {
         const temp = parseInt(char, 2);
-        if (isNaN(temp) || temp < 1 || temp > 8) throw new Error('Invalid FEN string. Invalid number in row');
+        if (isNaN(temp) || temp < 1 || temp > 8) throw new Error('Invalid Fen string. Invalid number in row');
         colIndex += temp;
       } else {
         const piece = letterToFigure(char as FigureLetter);
@@ -47,7 +60,7 @@ export const createChessBoardFromFEN = (fen: FEN): Board => {
   return board;
 };
 
-export const createFENFromChessBoard = (board: Board): FEN => {
+export const createFENFromChessBoard = (board: Board): Fen => {
   const rows: string[] = Array(8).fill('');
   board.forEach((square) => {
     const rowIndex = 8 - square.row;
@@ -82,7 +95,7 @@ export const createFENFromChessBoard = (board: Board): FEN => {
   });
 
   const piecePlacement = fenRows.join('/');
-  // Default values for other FEN fields
+  // Default values for other Fen fields
   const activeColor = 'w';
   const castlingAvailability = 'KQkq';
   const enPassantTarget = '-';

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -1,4 +1,4 @@
-import { isValidFEN } from './fen.ts';
+import { isValidFen } from './fen.ts';
 import { isNil, isNotNil } from './helper.ts';
 import {
   Fen,
@@ -30,8 +30,8 @@ const stringToPosition = (pos: string): Position => {
   return { column: col, row: row };
 };
 
-export const createChessBoardFromFEN = (fen: Fen): Board => {
-  if (!isValidFEN(fen)) throw new Error('Invalid Fen string');
+export const createChessBoardFromFen = (fen: Fen): Board => {
+  if (!isValidFen(fen)) throw new Error('Invalid Fen string');
 
   const [piecePlacement] = fen.split(' ');
   if (isNil(piecePlacement)) throw new Error('Invalid Fen string. No piece placement');
@@ -43,13 +43,13 @@ export const createChessBoardFromFEN = (fen: Fen): Board => {
 
   rows?.forEach((row, rowIndex) => {
     let colIndex = 0;
-    for (const char of row) {
-      if (/\d/.test(char)) {
-        const temp = parseInt(char, 2);
+    for (const figureLetter of row) {
+      if (/\d/.test(figureLetter)) {
+        const temp = parseInt(figureLetter, 10);
         if (isNaN(temp) || temp < 1 || temp > 8) throw new Error('Invalid Fen string. Invalid number in row');
         colIndex += temp;
       } else {
-        const piece = letterToFigure(char as FigureLetter);
+        const piece: Piece = letterToFigure(figureLetter);
         const position = coordinateToPosition(colIndex + 1, 8 - rowIndex);
         board.push({ ...position, ...piece });
         colIndex++;
@@ -60,7 +60,7 @@ export const createChessBoardFromFEN = (fen: Fen): Board => {
   return board;
 };
 
-export const createFENFromChessBoard = (board: Board): Fen => {
+export const createFenFromChessBoard = (board: Board): Fen => {
   const rows: string[] = Array(8).fill('');
   board.forEach((square) => {
     const rowIndex = 8 - square.row;

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -1,24 +1,7 @@
 import { FEN, isValidFEN } from './fen.ts';
 import { isNil, isNotNil } from './helper.ts';
-import {
-  Board,
-  FigureLetter,
-  Row,
-  Column,
-  Position,
-  BoardColorMap,
-  Color,
-  Piece,
-  CX,
-  CY,
-} from './types.ts';
-import {
-  rowToIndex,
-  columnToIndex,
-  coordinateToPosition,
-  letterToFigure,
-  figureToLetter,
-} from './transform.ts';
+import { Board, FigureLetter, Row, Column, Position, BoardColorMap, Color, Piece, CX, CY } from './types.ts';
+import { rowToIndex, columnToIndex, coordinateToPosition, letterToFigure, figureToLetter } from './transform.ts';
 
 export const positionToCoordinate = (position: Position): [CY, CX] => [
   rowToIndex(position.row),
@@ -28,12 +11,7 @@ const stringToPosition = (pos: string): Position => {
   if (pos.length !== 2) throw new Error('Invalid position string');
   const row = pos.charAt(0) as Row;
   const column = parseInt(pos.charAt(1), 10) as Column;
-  if (
-    !['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].includes(row) ||
-    isNaN(column) ||
-    column < 1 ||
-    column > 8
-  ) {
+  if (!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].includes(row) || isNaN(column) || column < 1 || column > 8) {
     throw new Error('Invalid position string');
   }
   return { row, column };
@@ -43,8 +21,7 @@ export const createChessBoardFromFEN = (fen: FEN): Board => {
   if (!isValidFEN(fen)) throw new Error('Invalid FEN string');
 
   const [piecePlacement] = fen.split(' ');
-  if (isNil(piecePlacement))
-    throw new Error('Invalid FEN string. No piece placement');
+  if (isNil(piecePlacement)) throw new Error('Invalid FEN string. No piece placement');
 
   const rows = piecePlacement?.split('/');
   if (rows?.length !== 8) throw new Error('Invalid FEN string. Not 8 rows');
@@ -56,8 +33,7 @@ export const createChessBoardFromFEN = (fen: FEN): Board => {
     for (const char of row) {
       if (/\d/.test(char)) {
         const temp = parseInt(char, 2);
-        if (isNaN(temp) || temp < 1 || temp > 8)
-          throw new Error('Invalid FEN string. Invalid number in row');
+        if (isNaN(temp) || temp < 1 || temp > 8) throw new Error('Invalid FEN string. Invalid number in row');
         colIndex += temp;
       } else {
         const piece = letterToFigure(char as FigureLetter);
@@ -117,17 +93,10 @@ export const createFENFromChessBoard = (board: Board): FEN => {
 };
 
 export const isPositionOccupied = (board: Board, position: Position): boolean =>
-  board.some(
-    (square) =>
-      square.row === position.row && square.column === position.column,
-  );
+  board.some((square) => square.row === position.row && square.column === position.column);
 // const getValidMoves = (from: Piece): Piece[] => [];
 
-export const setBoardMapColor = (
-  color: Color,
-  boardMap: BoardColorMap,
-  position: Position,
-): BoardColorMap => {
+export const setBoardMapColor = (color: Color, boardMap: BoardColorMap, position: Position): BoardColorMap => {
   const row = rowToIndex(position.row) - 1;
   const col = position.column - 1;
   if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {
@@ -137,9 +106,7 @@ export const setBoardMapColor = (
 };
 
 export const boardToPieceMap = (board: Board): (Piece | null)[][] => {
-  const boardMap: (Piece | null)[][] = Array.from({ length: 8 }, () =>
-    Array.from({ length: 8 }, () => null),
-  );
+  const boardMap: (Piece | null)[][] = Array.from({ length: 8 }, () => Array.from({ length: 8 }, () => null));
 
   board.forEach((square) => {
     const row = rowToIndex(square.row) - 1;
@@ -152,14 +119,9 @@ export const boardToPieceMap = (board: Board): (Piece | null)[][] => {
 };
 
 export const boardToColorMap = (board: Board): BoardColorMap =>
-  boardToPieceMap(board).map((row) =>
-    row.map((piece) => (isNil(piece) ? 'none' : piece.color)),
-  );
+  boardToPieceMap(board).map((row) => row.map((piece) => (isNil(piece) ? 'none' : piece.color)));
 
-export const getPieceFromPieceMap = (
-  boardMap: (Piece | null)[][],
-  position: Position,
-): Piece | null => {
+export const getPieceFromPieceMap = (boardMap: (Piece | null)[][], position: Position): Piece | null => {
   const row = rowToIndex(position.row) - 1;
   const col = position.column - 1;
   if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -9,9 +9,10 @@ export const positionToCoordinate = (position: Position): [CY, CX] => [
 ];
 
 export const createChessBoardFromFen = (fen: Fen): Board => {
+  //redundant parts of fen ignored for now
   if (!isValidFen(fen)) throw new Error('Invalid Fen string');
 
-  const [piecePlacement] = fen.split(' ');
+  const [piecePlacement] = fen.split(' '); //redundant parts ignored for now
   if (isNil(piecePlacement)) throw new Error('Invalid Fen string. No piece placement');
 
   const rows = piecePlacement?.split('/');

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -1,6 +1,6 @@
-import { FEN, isValidFEN } from './fen.ts';
+import { isValidFEN } from './fen.ts';
 import { isNil, isNotNil } from './helper.ts';
-import { Board, FigureLetter, Row, Column, Position, BoardColorMap, Color, Piece, CX, CY } from './types.ts';
+import { FEN, Board, FigureLetter, Row, Column, Position, BoardColorMap, Color, Piece, CX, CY } from './types.ts';
 import { rowToIndex, columnToIndex, coordinateToPosition, letterToFigure, figureToLetter } from './transform.ts';
 
 export const positionToCoordinate = (position: Position): [CY, CX] => [
@@ -9,12 +9,12 @@ export const positionToCoordinate = (position: Position): [CY, CX] => [
 ];
 const stringToPosition = (pos: string): Position => {
   if (pos.length !== 2) throw new Error('Invalid position string');
-  const row = pos.charAt(0) as Row;
-  const column = parseInt(pos.charAt(1), 10) as Column;
-  if (!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].includes(row) || isNaN(column) || column < 1 || column > 8) {
+  const col = pos.charAt(0) as Column;
+  const row = parseInt(pos.charAt(1), 10) as Row;
+  if (!['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].includes(col) || isNaN(row) || row < 1 || row > 8) {
     throw new Error('Invalid position string');
   }
-  return { row, column };
+  return { column: col, row: row };
 };
 
 export const createChessBoardFromFEN = (fen: FEN): Board => {
@@ -50,8 +50,8 @@ export const createChessBoardFromFEN = (fen: FEN): Board => {
 export const createFENFromChessBoard = (board: Board): FEN => {
   const rows: string[] = Array(8).fill('');
   board.forEach((square) => {
-    const rowIndex = 8 - square.column;
-    const colIndex = square.row.charCodeAt(0) - 'a'.charCodeAt(0);
+    const rowIndex = 8 - square.row;
+    const colIndex = square.column.charCodeAt(0) - 'a'.charCodeAt(0);
     rows[rowIndex] += figureToLetter({
       figure: square.figure,
       color: square.color,
@@ -98,7 +98,7 @@ export const isPositionOccupied = (board: Board, position: Position): boolean =>
 
 export const setBoardMapColor = (color: Color, boardMap: BoardColorMap, position: Position): BoardColorMap => {
   const row = rowToIndex(position.row) - 1;
-  const col = position.column - 1;
+  const col = columnToIndex(position.column) - 1;
   if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {
     boardMap[row][col] = color;
   }
@@ -110,7 +110,7 @@ export const boardToPieceMap = (board: Board): (Piece | null)[][] => {
 
   board.forEach((square) => {
     const row = rowToIndex(square.row) - 1;
-    const col = square.column - 1;
+    const col = columnToIndex(square.column) - 1;
     if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {
       boardMap[row][col] = { figure: square.figure, color: square.color };
     }
@@ -123,7 +123,7 @@ export const boardToColorMap = (board: Board): BoardColorMap =>
 
 export const getPieceFromPieceMap = (boardMap: (Piece | null)[][], position: Position): Piece | null => {
   const row = rowToIndex(position.row) - 1;
-  const col = position.column - 1;
+  const col = columnToIndex(position.column) - 1;
   if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {
     return boardMap[row][col];
   }

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -1,34 +1,12 @@
 import { isValidFen } from './fen.ts';
 import { isNil, isNotNil } from './helper.ts';
-import {
-  Fen,
-  Board,
-  FigureLetter,
-  Row,
-  Column,
-  Position,
-  BoardColorMap,
-  Color,
-  Piece,
-  CX,
-  CY,
-  Columns,
-} from './types.ts';
-import { rowToIndex, columnToIndex, coordinateToPosition, letterToFigure, figureToLetter } from './transform.ts';
+import { Fen, Board, Position, BoardColorMap, Color, Piece, CX, CY } from './types.ts';
+import { rowToIndex, columnToIndex, coordinateToPosition, letterToFigure } from './transform.ts';
 
 export const positionToCoordinate = (position: Position): [CY, CX] => [
   rowToIndex(position.row),
   columnToIndex(position.column),
 ];
-const stringToPosition = (pos: string): Position => {
-  if (pos.length !== 2) throw new Error('Invalid position string');
-  const col = pos.charAt(0) as Column;
-  const row = parseInt(pos.charAt(1), 10) as Row;
-  if (!Columns.includes(col) || isNaN(row) || row < 1 || row > 8) {
-    throw new Error('Invalid position string');
-  }
-  return { column: col, row: row };
-};
 
 export const createChessBoardFromFen = (fen: Fen): Board => {
   if (!isValidFen(fen)) throw new Error('Invalid Fen string');
@@ -59,55 +37,6 @@ export const createChessBoardFromFen = (fen: Fen): Board => {
 
   return board;
 };
-
-export const createFenFromChessBoard = (board: Board): Fen => {
-  const rows: string[] = Array(8).fill('');
-  board.forEach((square) => {
-    const rowIndex = 8 - square.row;
-    const colIndex = square.column.charCodeAt(0) - 'a'.charCodeAt(0);
-    rows[rowIndex] += figureToLetter({
-      figure: square.figure,
-      color: square.color,
-    });
-  });
-
-  const fenRows = rows.map((row) => {
-    let fenRow = '';
-    let emptyCount = 0;
-
-    for (const char of row) {
-      if (/[rnbqkpRNBQKP]/.test(char)) {
-        if (emptyCount > 0) {
-          fenRow += emptyCount.toString();
-          emptyCount = 0;
-        }
-        fenRow += char;
-      } else {
-        emptyCount++;
-      }
-    }
-
-    if (emptyCount > 0) {
-      fenRow += emptyCount.toString();
-    }
-
-    return fenRow;
-  });
-
-  const piecePlacement = fenRows.join('/');
-  // Default values for other Fen fields
-  const activeColor = 'w';
-  const castlingAvailability = 'KQkq';
-  const enPassantTarget = '-';
-  const halfmoveClock = '0';
-  const fullmoveNumber = '1';
-
-  return `${piecePlacement} ${activeColor} ${castlingAvailability} ${enPassantTarget} ${halfmoveClock} ${fullmoveNumber}`;
-};
-
-export const isPositionOccupied = (board: Board, position: Position): boolean =>
-  board.some((square) => square.row === position.row && square.column === position.column);
-// const getValidMoves = (from: Piece): Piece[] => [];
 
 export const setBoardMapColor = (color: Color, boardMap: BoardColorMap, position: Position): BoardColorMap => {
   const row = rowToIndex(position.row) - 1;
@@ -142,3 +71,5 @@ export const getPieceFromPieceMap = (boardMap: (Piece | null)[][], position: Pos
   }
   return null;
 };
+
+

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -1,0 +1,169 @@
+import { FEN, isValidFEN } from './fen.ts';
+import { isNil, isNotNil } from './helper.ts';
+import {
+  Board,
+  FigureLetter,
+  Row,
+  Column,
+  Position,
+  BoardColorMap,
+  Color,
+  Piece,
+  CX,
+  CY,
+} from './types.ts';
+import {
+  rowToIndex,
+  columnToIndex,
+  coordinateToPosition,
+  letterToFigure,
+  figureToLetter,
+} from './transform.ts';
+
+export const positionToCoordinate = (position: Position): [CY, CX] => [
+  rowToIndex(position.row),
+  columnToIndex(position.column),
+];
+const stringToPosition = (pos: string): Position => {
+  if (pos.length !== 2) throw new Error('Invalid position string');
+  const row = pos.charAt(0) as Row;
+  const column = parseInt(pos.charAt(1), 10) as Column;
+  if (
+    !['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].includes(row) ||
+    isNaN(column) ||
+    column < 1 ||
+    column > 8
+  ) {
+    throw new Error('Invalid position string');
+  }
+  return { row, column };
+};
+
+export const createChessBoardFromFEN = (fen: FEN): Board => {
+  if (!isValidFEN(fen)) throw new Error('Invalid FEN string');
+
+  const [piecePlacement] = fen.split(' ');
+  if (isNil(piecePlacement))
+    throw new Error('Invalid FEN string. No piece placement');
+
+  const rows = piecePlacement?.split('/');
+  if (rows?.length !== 8) throw new Error('Invalid FEN string. Not 8 rows');
+
+  const board: Board = [];
+
+  rows?.forEach((row, rowIndex) => {
+    let colIndex = 0;
+    for (const char of row) {
+      if (/\d/.test(char)) {
+        const temp = parseInt(char, 2);
+        if (isNaN(temp) || temp < 1 || temp > 8)
+          throw new Error('Invalid FEN string. Invalid number in row');
+        colIndex += temp;
+      } else {
+        const piece = letterToFigure(char as FigureLetter);
+        const position = coordinateToPosition(colIndex + 1, 8 - rowIndex);
+        board.push({ ...position, ...piece });
+        colIndex++;
+      }
+    }
+  });
+
+  return board;
+};
+
+export const createFENFromChessBoard = (board: Board): FEN => {
+  const rows: string[] = Array(8).fill('');
+  board.forEach((square) => {
+    const rowIndex = 8 - square.column;
+    const colIndex = square.row.charCodeAt(0) - 'a'.charCodeAt(0);
+    rows[rowIndex] += figureToLetter({
+      figure: square.figure,
+      color: square.color,
+    });
+  });
+
+  const fenRows = rows.map((row) => {
+    let fenRow = '';
+    let emptyCount = 0;
+
+    for (const char of row) {
+      if (/[rnbqkpRNBQKP]/.test(char)) {
+        if (emptyCount > 0) {
+          fenRow += emptyCount.toString();
+          emptyCount = 0;
+        }
+        fenRow += char;
+      } else {
+        emptyCount++;
+      }
+    }
+
+    if (emptyCount > 0) {
+      fenRow += emptyCount.toString();
+    }
+
+    return fenRow;
+  });
+
+  const piecePlacement = fenRows.join('/');
+  // Default values for other FEN fields
+  const activeColor = 'w';
+  const castlingAvailability = 'KQkq';
+  const enPassantTarget = '-';
+  const halfmoveClock = '0';
+  const fullmoveNumber = '1';
+
+  return `${piecePlacement} ${activeColor} ${castlingAvailability} ${enPassantTarget} ${halfmoveClock} ${fullmoveNumber}`;
+};
+
+export const isPositionOccupied = (board: Board, position: Position): boolean =>
+  board.some(
+    (square) =>
+      square.row === position.row && square.column === position.column,
+  );
+// const getValidMoves = (from: Piece): Piece[] => [];
+
+export const setBoardMapColor = (
+  color: Color,
+  boardMap: BoardColorMap,
+  position: Position,
+): BoardColorMap => {
+  const row = rowToIndex(position.row) - 1;
+  const col = position.column - 1;
+  if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {
+    boardMap[row][col] = color;
+  }
+  return boardMap;
+};
+
+export const boardToPieceMap = (board: Board): (Piece | null)[][] => {
+  const boardMap: (Piece | null)[][] = Array.from({ length: 8 }, () =>
+    Array.from({ length: 8 }, () => null),
+  );
+
+  board.forEach((square) => {
+    const row = rowToIndex(square.row) - 1;
+    const col = square.column - 1;
+    if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {
+      boardMap[row][col] = { figure: square.figure, color: square.color };
+    }
+  });
+  return boardMap;
+};
+
+export const boardToColorMap = (board: Board): BoardColorMap =>
+  boardToPieceMap(board).map((row) =>
+    row.map((piece) => (isNil(piece) ? 'none' : piece.color)),
+  );
+
+export const getPieceFromPieceMap = (
+  boardMap: (Piece | null)[][],
+  position: Position,
+): Piece | null => {
+  const row = rowToIndex(position.row) - 1;
+  const col = position.column - 1;
+  if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {
+    return boardMap[row][col];
+  }
+  return null;
+};

--- a/src/geometry/board.ts
+++ b/src/geometry/board.ts
@@ -1,6 +1,6 @@
 import { isValidFen } from './fen.ts';
 import { isNil, isNotNil } from './helper.ts';
-import { Fen, Board, Position, BoardColorMap, Color, Piece, CX, CY } from './types.ts';
+import { Fen, Board, Position, BoardColorMap, Color, Piece, CX, CY, BoardPieceMap } from './types.ts';
 import { rowToIndex, columnToIndex, coordinateToPosition, letterToFigure } from './transform.ts';
 
 export const positionToCoordinate = (position: Position): [CY, CX] => [
@@ -48,12 +48,12 @@ export const setBoardMapColor = (color: Color, boardMap: BoardColorMap, position
 };
 
 export const boardToPieceMap = (board: Board): (Piece | null)[][] => {
-  const boardMap: (Piece | null)[][] = Array.from({ length: 8 }, () => Array.from({ length: 8 }, () => null));
+  const boardMap: BoardPieceMap = Array.from({ length: 8 }, () => Array.from({ length: 8 }, () => null));
 
   board.forEach((square) => {
     const row = rowToIndex(square.row) - 1;
     const col = columnToIndex(square.column) - 1;
-    if (isNotNil(boardMap[row]) && isNotNil(boardMap[row][col])) {
+    if (boardMap[row] !== undefined && boardMap[row][col] !== undefined) {
       boardMap[row][col] = { figure: square.figure, color: square.color };
     }
   });

--- a/src/geometry/check.ts
+++ b/src/geometry/check.ts
@@ -62,7 +62,8 @@ const checkDirectionForCheck = (
             }
 
             if (piece.color === color) {
-              return false;
+              //not necessarly blocked by own piece
+              break;
             }
             break; //blocked by own piece or opponent piece
           }
@@ -75,8 +76,20 @@ const checkDirectionForCheck = (
   return false;
 };
 
-export const isPositionChecked = (kingPosition: Position, board: Board, color: Color) => {
-  const pieceMap = boardToPieceMap(board);
+export const isPositionChecked = (kingPosition: Position, board: Board, kingColor: Color) => {
+  const color = kingColor; //the color of the king we are checking
+
+  const pieceMap = boardToPieceMap(board).map((row) =>
+    row.map((piece) => {
+      // Remove the king of the same color from the pieceMap
+      // own king should not block checks
+      if (piece?.figure === 'KING' && piece.color === color) {
+        return null;
+      }
+      return piece;
+    }),
+  );
+
   if (isNil(kingPosition)) {
     throw new Error('King not found on the board');
   } else {

--- a/src/geometry/check.ts
+++ b/src/geometry/check.ts
@@ -1,63 +1,82 @@
-import { Board, Color, Position, Direction, BoardPieceMap, Figure } from './types.ts';
+import { Board, Color, Position, Direction, BoardPieceMap, Figure, Piece } from './types.ts';
 import { boardToPieceMap, positionToCoordinate, getPieceFromPieceMap } from './board.ts';
 import { coordinateToPosition } from './transform.ts';
-import { isNil, isNotNil } from './helper.ts';
+import { isIndexInBound, isNil, isNotNil } from './helper.ts';
 import { calculateMoveListForKing } from './move.ts';
 
+const isOpponentKing = (color: Color, piece: Piece | null): boolean =>
+  isNotNil(piece) && piece.figure === 'KING' && color !== piece.color;
+
 const isPawnDirectionCorrect = (direction: Direction, color: Color) =>
-  (color === 'white' && direction.row === 1) || (color === 'black' && direction.row === -1);
+  (color === 'black' && direction.row === 1) || (color === 'white' && direction.row === -1);
 
 const checkDirectionForCheck = (
   pieceMap: BoardPieceMap,
   kingPosition: Position | undefined,
   directions: readonly Direction[],
   color: Color,
-  targetFigures: Figure[],
+  targetFigures: readonly Figure[],
   siftBoard: boolean = true,
 ) => {
-  directions.map((direction) => {
-    let step = siftBoard ? 1 : 7;
-    while (step < 8 && isNotNil(kingPosition)) {
-      //maybe a better way instead of using typeguard
-      const stepTemp = siftBoard ? step : 1;
+  if (kingPosition === undefined) {
+    return false;
+  } else {
+    const current = positionToCoordinate(kingPosition);
+    const upperBound = siftBoard ? 8 : 2; //2 for knight
+    for (const direction of directions) {
+      let step = 1;
 
-      const updatedRow = positionToCoordinate(kingPosition)[0] + direction.row * stepTemp;
-      const updatedCol = positionToCoordinate(kingPosition)[1] + direction.col * stepTemp;
-      const piece = getPieceFromPieceMap(pieceMap, coordinateToPosition(updatedCol, updatedRow));
-      if (piece !== null) {
-        if (
-          //check for pawn attack
-          step === 1 &&
-          piece.figure === 'PAWN' &&
-          targetFigures.includes('BISHOP') &&
-          piece.color !== color &&
-          isPawnDirectionCorrect(direction, piece.color)
-        ) {
-          return true;
-        }
+      while (step < upperBound) {
+        //maybe a better way instead of using typeguard
+        const stepTemp = siftBoard ? step : 1;
 
-        if (piece.color !== color && targetFigures.includes(piece.figure)) {
-          return true;
+        const updatedRow = current[0] + direction.row * stepTemp;
+        const updatedCol = current[1] + direction.col * stepTemp;
+        const isInBound = isIndexInBound(updatedRow) && isIndexInBound(updatedCol);
+        if (isInBound) {
+          const piece = getPieceFromPieceMap(pieceMap, coordinateToPosition(updatedCol, updatedRow));
+          if (piece !== null) {
+            if (
+              //check for pawn attack
+              piece.color !== color &&
+              step === 1 //only 1 step away
+            ) {
+              if (
+                piece.figure === 'PAWN' &&
+                targetFigures.includes('BISHOP') &&
+                isPawnDirectionCorrect(direction, piece.color)
+              ) {
+                return true;
+              }
+            }
+
+            const isTargetPiece = piece.color !== color && targetFigures.includes(piece.figure);
+            if (isTargetPiece) {
+              //f.ex. bishop or queen in diagonal direction
+              return true;
+            }
+
+            if (isOpponentKing(color, piece) && step === 1 && !targetFigures.includes('KNIGHT')) {
+              return true; //king is next to king
+              //hypothetical king check
+            }
+
+            if (piece.color === color) {
+              return false;
+            }
+            break; //blocked by own piece or opponent piece
+          }
         }
-        break; //blocked by own piece or opponent piece
+        //found piece in this direction
+        ++step;
       }
-      //found piece in this direction
-      ++step;
     }
-  });
+  }
   return false;
 };
 
-const isPositionChecked = (position: Position, board: Board) => {};
-
-const findKingPosition = (board: Board, color: Color): Position | undefined => {
-  const kingSquare = board.find((square) => square.figure === 'KING' && square.color === color);
-  return kingSquare ? { row: kingSquare.row, column: kingSquare.column } : undefined;
-};
-
-export const isKingChecked = (board: Board, color: Color): boolean => {
+export const isPositionChecked = (kingPosition: Position, board: Board, color: Color) => {
   const pieceMap = boardToPieceMap(board);
-  const kingPosition = findKingPosition(board, color);
   if (isNil(kingPosition)) {
     throw new Error('King not found on the board');
   } else {
@@ -90,8 +109,23 @@ export const isKingChecked = (board: Board, color: Color): boolean => {
     if (checkDirectionForCheck(pieceMap, kingPosition, bishopDirection, color, ['BISHOP', 'QUEEN'])) return true;
     //check by rook or queen
     if (checkDirectionForCheck(pieceMap, kingPosition, rookDirection, color, ['ROOK', 'QUEEN'])) return true;
+    //check by knight
     if (checkDirectionForCheck(pieceMap, kingPosition, knightMoves, color, ['KNIGHT'], false)) return true;
     return false;
+  }
+};
+
+const findKingPosition = (board: Board, color: Color): Position | undefined => {
+  const kingSquare = board.find((square) => square.figure === 'KING' && square.color === color);
+  return kingSquare ? { row: kingSquare.row, column: kingSquare.column } : undefined;
+};
+
+export const isKingChecked = (board: Board, kingColor: Color): boolean => {
+  const kingPosition = findKingPosition(board, kingColor);
+  if (kingPosition === undefined) {
+    throw new Error('King not found on the board');
+  } else {
+    return isPositionChecked(kingPosition, board, kingColor);
   }
 };
 

--- a/src/geometry/check.ts
+++ b/src/geometry/check.ts
@@ -121,6 +121,7 @@ const findKingPosition = (board: Board, color: Color): Position | undefined => {
 };
 
 export const isKingChecked = (board: Board, kingColor: Color): boolean => {
+  if (kingColor === 'none') return false;
   const kingPosition = findKingPosition(board, kingColor);
   if (kingPosition === undefined) {
     throw new Error('King not found on the board');
@@ -135,7 +136,8 @@ export const isCheckMate = (board: Board, color: Color): boolean => {
   if (position === undefined) {
     throw new Error('King not found on the board');
   } else {
-    return calculateMoveListForKing(position, board).length === 0 && isKingChecked(board, color);
+    const kingIsChecked = isKingChecked(board, color);
+    return calculateMoveListForKing(position, board, kingIsChecked).length === 0;
   }
 };
 
@@ -146,6 +148,10 @@ export const isStaleMate = (board: Board, color: Color): boolean => {
   if (position === undefined) {
     throw new Error('King not found on the board');
   } else {
-    return calculateMoveListForKing(position, board).length === 0 && !isKingChecked(board, color);
+    const kingIsntChecked = !isKingChecked(board, color);
+    return calculateMoveListForKing(position, board, kingIsntChecked).length === 0;
   }
 };
+
+export const wouldPositionBeChecked = (board: Board, kingPosition: Position, color: Color): boolean =>
+  isPositionChecked(kingPosition, board, color);

--- a/src/geometry/check.ts
+++ b/src/geometry/check.ts
@@ -1,0 +1,117 @@
+import { Board, Color, Position, Direction, BoardPieceMap, Figure } from './types.ts';
+import { boardToPieceMap, positionToCoordinate, getPieceFromPieceMap } from './board.ts';
+import { coordinateToPosition } from './transform.ts';
+import { isNil, isNotNil } from './helper.ts';
+import { calculateMoveListForKing } from './move.ts';
+
+const isPawnDirectionCorrect = (direction: Direction, color: Color) =>
+  (color === 'white' && direction.row === 1) || (color === 'black' && direction.row === -1);
+
+const checkDirectionForCheck = (
+  pieceMap: BoardPieceMap,
+  kingPosition: Position | undefined,
+  directions: readonly Direction[],
+  color: Color,
+  targetFigures: Figure[],
+  siftBoard: boolean = true,
+) => {
+  directions.map((direction) => {
+    let step = siftBoard ? 1 : 7;
+    while (step < 8 && isNotNil(kingPosition)) {
+      //maybe a better way instead of using typeguard
+      const stepTemp = siftBoard ? step : 1;
+
+      const updatedRow = positionToCoordinate(kingPosition)[0] + direction.row * stepTemp;
+      const updatedCol = positionToCoordinate(kingPosition)[1] + direction.col * stepTemp;
+      const piece = getPieceFromPieceMap(pieceMap, coordinateToPosition(updatedCol, updatedRow));
+      if (piece !== null) {
+        if (
+          //check for pawn attack
+          step === 1 &&
+          piece.figure === 'PAWN' &&
+          targetFigures.includes('BISHOP') &&
+          piece.color !== color &&
+          isPawnDirectionCorrect(direction, piece.color)
+        ) {
+          return true;
+        }
+
+        if (piece.color !== color && targetFigures.includes(piece.figure)) {
+          return true;
+        }
+        break; //blocked by own piece or opponent piece
+      }
+      //found piece in this direction
+      ++step;
+    }
+  });
+  return false;
+};
+
+const isPositionChecked = (position: Position, board: Board) => {};
+
+const findKingPosition = (board: Board, color: Color): Position | undefined => {
+  const kingSquare = board.find((square) => square.figure === 'KING' && square.color === color);
+  return kingSquare ? { row: kingSquare.row, column: kingSquare.column } : undefined;
+};
+
+export const isKingChecked = (board: Board, color: Color): boolean => {
+  const pieceMap = boardToPieceMap(board);
+  const kingPosition = findKingPosition(board, color);
+  if (isNil(kingPosition)) {
+    throw new Error('King not found on the board');
+  } else {
+    const bishopDirection = [
+      { row: 1, col: 1 },
+      { row: 1, col: -1 },
+      { row: -1, col: 1 },
+      { row: -1, col: -1 },
+    ] as const;
+    const rookDirection = [
+      { row: 1, col: 0 },
+      { row: -1, col: 0 },
+      { row: 0, col: 1 },
+      { row: 0, col: -1 },
+    ] as const;
+
+    //check by knight
+    const knightMoves = [
+      { row: 2, col: 1 },
+      { row: 2, col: -1 },
+      { row: -2, col: 1 },
+      { row: -2, col: -1 },
+      { row: 1, col: 2 },
+      { row: 1, col: -2 },
+      { row: -1, col: 2 },
+      { row: -1, col: -2 },
+    ] as const;
+
+    //check by bishop or queen
+    if (checkDirectionForCheck(pieceMap, kingPosition, bishopDirection, color, ['BISHOP', 'QUEEN'])) return true;
+    //check by rook or queen
+    if (checkDirectionForCheck(pieceMap, kingPosition, rookDirection, color, ['ROOK', 'QUEEN'])) return true;
+    if (checkDirectionForCheck(pieceMap, kingPosition, knightMoves, color, ['KNIGHT'], false)) return true;
+    return false;
+  }
+};
+
+export const isCheckMate = (board: Board, color: Color): boolean => {
+  //king has no moves.. and is checked
+  const position = findKingPosition(board, color);
+  if (position === undefined) {
+    throw new Error('King not found on the board');
+  } else {
+    return calculateMoveListForKing(position, board).length === 0 && isKingChecked(board, color);
+  }
+};
+
+export const isStaleMate = (board: Board, color: Color): boolean => {
+  //king has no moves.. and is not checked
+  //king has no moves.. and is checked
+  const position = findKingPosition(board, color);
+  if (position === undefined) {
+    throw new Error('King not found on the board');
+  } else {
+    return calculateMoveListForKing(position, board).length === 0 && !isKingChecked(board, color);
+  }
+};

--- a/src/geometry/constant.ts
+++ b/src/geometry/constant.ts
@@ -1,0 +1,7 @@
+import type { Fen } from './types.ts';
+
+export const WHITE_EN_PASSENT_ROW = 5;
+export const BLACK_EN_PASSENT_ROW = 4;
+export const SECOND_ROW = 2;
+export const SEVENTH_ROW = 7;
+export const INIT_POSITION: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';

--- a/src/geometry/fen.ts
+++ b/src/geometry/fen.ts
@@ -1,3 +1,5 @@
+import { isNil } from './helper.ts';
+
 export type FEN = string;
 export const INIT_POSITION: FEN =
   'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
@@ -6,8 +8,7 @@ const validFEN =
   /\s*^(((?:[rnbqkpRNBQKP1-8]+\/){7})[rnbqkpRNBQKP1-8]+)\s([b|w])\s([K|Q|k|q]{1,4}|-)\s(-|[a-h][1-8])\s(\d+\s\d+)/;
 
 const hasOneKingPerSide = (position: FEN) => {
-  const rows = position.split(' ')
-    .at(0)?.split('/') ?? [];
+  const rows = position.split(' ').at(0)?.split('/') ?? [];
   const flatPosition = rows.join('');
   const whiteKingCount = (flatPosition.match(/K/g) || []).length;
   const blackKingCount = (flatPosition.match(/k/g) || []).length;
@@ -16,16 +17,39 @@ const hasOneKingPerSide = (position: FEN) => {
 
 const checkForMaxPiecesPerRow = (position: FEN) =>
   /*should have at max 8 squares (alphabetical letters) per row */
-  position.split(' ')
-    .at(0)?.split('/')
+  position
+    .split(' ')
+    .at(0)
+    ?.split('/')
     .every((row) => {
       const piecesInRow = Array.from(row)
         .map((char) => (isNaN(parseInt(char)) ? 1 : parseInt(char)))
         .reduce((a, b) => a + b, 0);
       return piecesInRow <= 8;
-    }) ?? false
+    }) ?? false;
 
-export const checkValidFEN = (position: FEN) =>
-  validFEN.test(position) && 
-  checkForMaxPiecesPerRow(position) && 
+export const isValidFENSyntax = (position: FEN): boolean =>
+  validFEN.test(position) &&
+  checkForMaxPiecesPerRow(position) &&
   hasOneKingPerSide(position);
+
+export const additionalFENTests = (fen: FEN): boolean => {
+  const parts = fen.split(' ');
+  if (parts.length !== 6) {
+    return false;
+  }
+  const [piecePlacement] = parts;
+  if (isNil(piecePlacement)) return false;
+
+  const rows = piecePlacement?.split('/');
+  if (rows?.length !== 8) return false;
+  return true;
+};
+export const isValidFEN = (position: FEN): boolean =>
+  isValidFENSyntax(position) && additionalFENTests(position);
+
+export const extractPiecePlacementFromFEN = (position: FEN) => {
+  return position.split(' ').at(0) ?? '';
+};
+
+export const isNewGameFEN = (position: FEN) => position === INIT_POSITION;

--- a/src/geometry/fen.ts
+++ b/src/geometry/fen.ts
@@ -1,6 +1,6 @@
 import { isNil } from './helper.ts';
+import { FEN } from './types.ts';
 
-export type FEN = string;
 export const INIT_POSITION: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
 const validFEN =

--- a/src/geometry/fen.ts
+++ b/src/geometry/fen.ts
@@ -1,8 +1,7 @@
 import { isNil } from './helper.ts';
 
 export type FEN = string;
-export const INIT_POSITION: FEN =
-  'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+export const INIT_POSITION: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
 const validFEN =
   /\s*^(((?:[rnbqkpRNBQKP1-8]+\/){7})[rnbqkpRNBQKP1-8]+)\s([b|w])\s([K|Q|k|q]{1,4}|-)\s(-|[a-h][1-8])\s(\d+\s\d+)/;
@@ -29,9 +28,7 @@ const checkForMaxPiecesPerRow = (position: FEN) =>
     }) ?? false;
 
 export const isValidFENSyntax = (position: FEN): boolean =>
-  validFEN.test(position) &&
-  checkForMaxPiecesPerRow(position) &&
-  hasOneKingPerSide(position);
+  validFEN.test(position) && checkForMaxPiecesPerRow(position) && hasOneKingPerSide(position);
 
 export const additionalFENTests = (fen: FEN): boolean => {
   const parts = fen.split(' ');
@@ -45,8 +42,7 @@ export const additionalFENTests = (fen: FEN): boolean => {
   if (rows?.length !== 8) return false;
   return true;
 };
-export const isValidFEN = (position: FEN): boolean =>
-  isValidFENSyntax(position) && additionalFENTests(position);
+export const isValidFEN = (position: FEN): boolean => isValidFENSyntax(position) && additionalFENTests(position);
 
 export const extractPiecePlacementFromFEN = (position: FEN) => {
   return position.split(' ').at(0) ?? '';

--- a/src/geometry/fen.ts
+++ b/src/geometry/fen.ts
@@ -1,5 +1,7 @@
 import { isNil } from './helper.ts';
 import { Fen } from './types.ts';
+import { Board } from './types.ts';
+import { figureToLetter } from './transform.ts';
 
 export const INIT_POSITION: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
@@ -49,3 +51,60 @@ export const extractPiecePlacementFromFen = (position: Fen) => {
 };
 
 export const isNewGameFEN = (position: Fen) => position === INIT_POSITION;
+
+// export const extractCastlingRightsFromFen = (fen: Fen) => {
+//   const parts = fen.split(' ');
+//   if (parts.length < 3) throw new Error('Invalid Fen string');
+//   const castlingPart = parts[2];
+//   return {
+//     whiteKingSideCastle: castlingPart.includes('K'),
+//     whiteQueenSideCastle: castlingPart.includes('Q'),
+//     blackKingSideCastle: castlingPart.includes('k'),
+//     blackQueenSideCastle: castlingPart.includes('q'),
+//   };
+// };
+
+export const createFenFromChessBoard = (board: Board): Fen => {
+  const rows: string[] = Array(8).fill('');
+  board.forEach((square) => {
+    const rowIndex = 8 - square.row;
+    const colIndex = square.column.charCodeAt(0) - 'a'.charCodeAt(0);
+    rows[rowIndex] += figureToLetter({
+      figure: square.figure,
+      color: square.color,
+    });
+  });
+
+  const fenRows = rows.map((row) => {
+    let fenRow = '';
+    let emptyCount = 0;
+
+    for (const char of row) {
+      if (/[rnbqkpRNBQKP]/.test(char)) {
+        if (emptyCount > 0) {
+          fenRow += emptyCount.toString();
+          emptyCount = 0;
+        }
+        fenRow += char;
+      } else {
+        emptyCount++;
+      }
+    }
+
+    if (emptyCount > 0) {
+      fenRow += emptyCount.toString();
+    }
+
+    return fenRow;
+  });
+
+  const piecePlacement = fenRows.join('/');
+  // Default values for other Fen fields
+  const activeColor = 'w';
+  const castlingAvailability = 'KQkq';
+  const enPassantTarget = '-';
+  const halfmoveClock = '0';
+  const fullmoveNumber = '1';
+
+  return `${piecePlacement} ${activeColor} ${castlingAvailability} ${enPassantTarget} ${halfmoveClock} ${fullmoveNumber}`;
+};

--- a/src/geometry/fen.ts
+++ b/src/geometry/fen.ts
@@ -1,9 +1,7 @@
+import { INIT_POSITION } from './constant.ts';
 import { isNil } from './helper.ts';
-import { Fen } from './types.ts';
-import { Board } from './types.ts';
+import { Fen, Board } from './types.ts';
 import { figureToLetter } from './transform.ts';
-
-export const INIT_POSITION: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
 const validFen =
   /\s*^(((?:[rnbqkpRNBQKP1-8]+\/){7})[rnbqkpRNBQKP1-8]+)\s([b|w])\s([K|Q|k|q]{1,4}|-)\s(-|[a-h][1-8])\s(\d+\s\d+)/;
@@ -14,6 +12,12 @@ const hasOneKingPerSide = (position: Fen) => {
   const whiteKingCount = (flatPosition.match(/K/g) || []).length;
   const blackKingCount = (flatPosition.match(/k/g) || []).length;
   return whiteKingCount === 1 && blackKingCount === 1;
+};
+
+export const validFenFrom = (fen: Fen) => {
+  if (isValidFen(fen)) {
+    return fen;
+  } else throw new Error('Invalid FEN string');
 };
 
 const checkForMaxPiecesPerRow = (position: Fen) =>

--- a/src/geometry/fen.ts
+++ b/src/geometry/fen.ts
@@ -3,7 +3,7 @@ import { Fen } from './types.ts';
 
 export const INIT_POSITION: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
-const validFEN =
+const validFen =
   /\s*^(((?:[rnbqkpRNBQKP1-8]+\/){7})[rnbqkpRNBQKP1-8]+)\s([b|w])\s([K|Q|k|q]{1,4}|-)\s(-|[a-h][1-8])\s(\d+\s\d+)/;
 
 const hasOneKingPerSide = (position: Fen) => {
@@ -27,10 +27,10 @@ const checkForMaxPiecesPerRow = (position: Fen) =>
       return piecesInRow <= 8;
     }) ?? false;
 
-export const isValidFENSyntax = (position: Fen): boolean =>
-  validFEN.test(position) && checkForMaxPiecesPerRow(position) && hasOneKingPerSide(position);
+export const isValidFenSyntax = (position: Fen): boolean =>
+  validFen.test(position) && checkForMaxPiecesPerRow(position) && hasOneKingPerSide(position);
 
-export const additionalFENTests = (fen: Fen): boolean => {
+export const additionalFenTests = (fen: Fen): boolean => {
   const parts = fen.split(' ');
   if (parts.length !== 6) {
     return false;
@@ -42,9 +42,9 @@ export const additionalFENTests = (fen: Fen): boolean => {
   if (rows?.length !== 8) return false;
   return true;
 };
-export const isValidFEN = (position: Fen): boolean => isValidFENSyntax(position) && additionalFENTests(position);
+export const isValidFen = (position: Fen): boolean => isValidFenSyntax(position) && additionalFenTests(position);
 
-export const extractPiecePlacementFromFEN = (position: Fen) => {
+export const extractPiecePlacementFromFen = (position: Fen) => {
   return position.split(' ').at(0) ?? '';
 };
 

--- a/src/geometry/fen.ts
+++ b/src/geometry/fen.ts
@@ -1,12 +1,12 @@
 import { isNil } from './helper.ts';
-import { FEN } from './types.ts';
+import { Fen } from './types.ts';
 
-export const INIT_POSITION: FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+export const INIT_POSITION: Fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
 const validFEN =
   /\s*^(((?:[rnbqkpRNBQKP1-8]+\/){7})[rnbqkpRNBQKP1-8]+)\s([b|w])\s([K|Q|k|q]{1,4}|-)\s(-|[a-h][1-8])\s(\d+\s\d+)/;
 
-const hasOneKingPerSide = (position: FEN) => {
+const hasOneKingPerSide = (position: Fen) => {
   const rows = position.split(' ').at(0)?.split('/') ?? [];
   const flatPosition = rows.join('');
   const whiteKingCount = (flatPosition.match(/K/g) || []).length;
@@ -14,7 +14,7 @@ const hasOneKingPerSide = (position: FEN) => {
   return whiteKingCount === 1 && blackKingCount === 1;
 };
 
-const checkForMaxPiecesPerRow = (position: FEN) =>
+const checkForMaxPiecesPerRow = (position: Fen) =>
   /*should have at max 8 squares (alphabetical letters) per row */
   position
     .split(' ')
@@ -27,10 +27,10 @@ const checkForMaxPiecesPerRow = (position: FEN) =>
       return piecesInRow <= 8;
     }) ?? false;
 
-export const isValidFENSyntax = (position: FEN): boolean =>
+export const isValidFENSyntax = (position: Fen): boolean =>
   validFEN.test(position) && checkForMaxPiecesPerRow(position) && hasOneKingPerSide(position);
 
-export const additionalFENTests = (fen: FEN): boolean => {
+export const additionalFENTests = (fen: Fen): boolean => {
   const parts = fen.split(' ');
   if (parts.length !== 6) {
     return false;
@@ -42,10 +42,10 @@ export const additionalFENTests = (fen: FEN): boolean => {
   if (rows?.length !== 8) return false;
   return true;
 };
-export const isValidFEN = (position: FEN): boolean => isValidFENSyntax(position) && additionalFENTests(position);
+export const isValidFEN = (position: Fen): boolean => isValidFENSyntax(position) && additionalFENTests(position);
 
-export const extractPiecePlacementFromFEN = (position: FEN) => {
+export const extractPiecePlacementFromFEN = (position: Fen) => {
   return position.split(' ').at(0) ?? '';
 };
 
-export const isNewGameFEN = (position: FEN) => position === INIT_POSITION;
+export const isNewGameFEN = (position: Fen) => position === INIT_POSITION;

--- a/src/geometry/game.ts
+++ b/src/geometry/game.ts
@@ -1,0 +1,6 @@
+//castling stuff to be implemented
+//promotion to be implemented
+//is draw  by insufficient material to be implemented
+//is draw by 50 move rule to be implemented
+//is draw by threefold repetition to be implemented
+//is draw by dead position to be implemented

--- a/src/geometry/helper.ts
+++ b/src/geometry/helper.ts
@@ -8,4 +8,3 @@ export function isNotNil<T>(value?: T): value is NonNullable<T> {
 
 export const isIndexInBound = (index: number): boolean => index >= 0 && index < 8;
 
-//how to avoid infinite loop here?

--- a/src/geometry/helper.ts
+++ b/src/geometry/helper.ts
@@ -1,0 +1,16 @@
+export function isNil(value: unknown): value is null {
+  return (
+    value === null ||
+    value === undefined ||
+    (typeof value === 'number' && isNaN(value))
+  );
+}
+
+export function isNotNil<T>(value?: T): value is NonNullable<T> {
+  return !isNil(value);
+}
+
+export const isIndexInBound = (index: number): boolean =>
+  index >= 0 && index < 8;
+
+//how to avoid infinite loop here?

--- a/src/geometry/helper.ts
+++ b/src/geometry/helper.ts
@@ -1,16 +1,11 @@
 export function isNil(value: unknown): value is null {
-  return (
-    value === null ||
-    value === undefined ||
-    (typeof value === 'number' && isNaN(value))
-  );
+  return value === null || value === undefined || (typeof value === 'number' && isNaN(value));
 }
 
 export function isNotNil<T>(value?: T): value is NonNullable<T> {
   return !isNil(value);
 }
 
-export const isIndexInBound = (index: number): boolean =>
-  index >= 0 && index < 8;
+export const isIndexInBound = (index: number): boolean => index >= 0 && index < 8;
 
 //how to avoid infinite loop here?

--- a/src/geometry/helper.ts
+++ b/src/geometry/helper.ts
@@ -6,5 +6,5 @@ export function isNotNil<T>(value?: T): value is NonNullable<T> {
   return !isNil(value);
 }
 
-export const isIndexInBound = (index: number): boolean => index >= 0 && index < 8;
+export const isIndexInBound = (index: number): boolean => index > 0 && index <= 8; //index from 1..8
 

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -167,6 +167,7 @@ export const calculateMoveListForKing = (
   const pieceMap = boardToPieceMap(board);
   const boardColorMap = pieceMap.map((row) => row.map((piece) => (isNil(piece) ? 'none' : piece.color)));
   const color = extractColorFromMap(boardColorMap, from);
+  const boardWithoutKing = board.filter((piece) => piece.row !== from.row && piece.column !== from.column);
 
   const kingMoves = [
     { row: 1, col: 0 },
@@ -187,7 +188,12 @@ export const calculateMoveListForKing = (
     if (isInBound) {
       //only add move if king will not be in check!
       // <=> king is not touching other king
-      const updatedPosIsThreat = wouldPositionBeChecked(board, updatedPos, color);
+      const updatedPosIsThreat = wouldPositionBeChecked(
+        //remove king from board to avoid blocking the algorithm
+        boardWithoutKing,
+        updatedPos,
+        color,
+      );
 
       //only add move if path isn't blocked by own piece
       //and if new position is not threatened by opponent piece
@@ -196,6 +202,7 @@ export const calculateMoveListForKing = (
       }
     }
   });
+
   //castling logic
   //evaluated externally:
   //king has moved, prevents color castling
@@ -216,20 +223,15 @@ export const calculateMoveListForKing = (
       (fromColor === 'white' &&
         isPathEmpty(boardColorMap, { row: 1, column: 'f' }) &&
         isPathEmpty(boardColorMap, { row: 1, column: 'g' }) &&
-        !wouldPositionBeChecked(board, { row: 1, column: 'f' }, fromColor) &&
-        !wouldPositionBeChecked(board, { row: 1, column: 'g' }, fromColor)) ||
+        !wouldPositionBeChecked(boardWithoutKing, { row: 1, column: 'f' }, fromColor) &&
+        !wouldPositionBeChecked(boardWithoutKing, { row: 1, column: 'g' }, fromColor)) ||
       (fromColor === 'black' &&
         isPathEmpty(boardColorMap, { row: 8, column: 'f' }) &&
         isPathEmpty(boardColorMap, { row: 8, column: 'g' }) &&
-        !wouldPositionBeChecked(board, { row: 8, column: 'f' }, fromColor) &&
-        !wouldPositionBeChecked(board, { row: 8, column: 'g' }, fromColor))
+        !wouldPositionBeChecked(boardWithoutKing, { row: 8, column: 'f' }, fromColor) &&
+        !wouldPositionBeChecked(boardWithoutKing, { row: 8, column: 'g' }, fromColor))
     ) {
-      moves.push({
-        row: from.row,
-        column: 'g',
-        isTaken: false,
-        isCastle: fromColor === 'white' ? 'K' : 'k',
-      });
+      moves.push({ row: from.row, column: 'g', isTaken: false, isCastle: fromColor === 'white' ? 'K' : 'k' });
     }
     //queen side castling
     if (
@@ -246,7 +248,7 @@ export const calculateMoveListForKing = (
         !wouldPositionBeChecked(board, { row: 8, column: 'd' }, fromColor) &&
         !wouldPositionBeChecked(board, { row: 8, column: 'c' }, fromColor))
     ) {
-      moves.push({ row: from.row, column: 'c', isTaken: false });
+      moves.push({ row: from.row, column: 'c', isTaken: false, isCastle: fromColor === 'white' ? 'Q' : 'q' });
     }
   }
 

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -54,27 +54,29 @@ export const calculateMoveListForBishop = (from: Position, board: Board): Move[]
   directions.map((direction) => {
     let step = 1;
     while (step < 8) {
+      //make sure that it's not infinite loop
       //maybe use range here?..how to break then.. return..
       const updatedRow = current[0] + direction.row * step;
       const updatedCol = current[1] + direction.col * step;
-      const pathBlocked = isPathBlocked(
-        boardColorMap,
-        coordinateToPosition(updatedCol, updatedRow),
-        extractPositionFromMap(boardColorMap, from),
-      );
-      if (isIndexInBound(updatedRow) && isIndexInBound(updatedCol) && !pathBlocked) {
-        moves.push({
-          ...coordinateToPosition(updatedCol, updatedRow),
-          isTaken: isPieceTaken(
-            boardColorMap,
-            coordinateToPosition(updatedCol, updatedRow),
-            extractPositionFromMap(boardColorMap, from),
-          ),
-        });
+      const isInBound = isIndexInBound(updatedRow) && isIndexInBound(updatedCol);
+      let pathBlocked = false;
+
+      if (isInBound) {
+        const pos = coordinateToPosition(updatedCol, updatedRow);
+        pathBlocked = isPathBlocked(boardColorMap, pos, extractPositionFromMap(boardColorMap, from));
+        if (!pathBlocked) {
+          //add if not blocked means that piece gets taken or empty square
+          moves.push({
+            ...pos,
+            isTaken: isPieceTaken(boardColorMap, pos, extractPositionFromMap(boardColorMap, from)),
+          });
+        }
       } else {
+        //if coordinates are out of bounds, break the loop
         break;
       }
       if (pathBlocked) {
+        //if path is blocked, there is no reason to continue in this direction
         break;
       }
 
@@ -188,14 +190,15 @@ export const calculateMoveListForQueen = (from: Position, board: Board): Move[] 
       //this could be optimized by extracting common logic with rook and bishop
       //it's repeated code
       //maybe extract this later to a helper function
-      const updatedRow = current[0] + direction.row * step;
-      const updatedCol = current[1] + direction.col * step;
+      const updatedRow = current[0] + direction.row * step + 1;
+      const updatedCol = current[1] + direction.col * step + 1;
+      const isInBound = isIndexInBound(updatedRow) && isIndexInBound(updatedCol);
       const pathBlocked = isPathBlocked(
         boardColorMap,
         coordinateToPosition(updatedCol, updatedRow),
         extractPositionFromMap(boardColorMap, from),
       );
-      if (isIndexInBound(updatedRow) && isIndexInBound(updatedCol) && !pathBlocked) {
+      if (isInBound && !pathBlocked) {
         moves.push({
           ...coordinateToPosition(updatedCol, updatedRow),
           isTaken: isPieceTaken(

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -216,38 +216,52 @@ export const calculateMoveListForKing = (
 
   const fromColor = extractColorFromMap(boardColorMap, from);
   if (isCastlingPossible && !isKingChecked) {
-    //king side castling
-    if (
-      (fromColor === 'white' &&
+    if (fromColor === 'white') {
+      //white king side castling
+      if (
         isPathEmpty(boardColorMap, { row: 1, column: 'f' }) &&
         isPathEmpty(boardColorMap, { row: 1, column: 'g' }) &&
         !wouldPositionBeChecked(boardWithoutKing, { row: 1, column: 'f' }, fromColor) &&
-        !wouldPositionBeChecked(boardWithoutKing, { row: 1, column: 'g' }, fromColor)) ||
-      (fromColor === 'black' &&
-        isPathEmpty(boardColorMap, { row: 8, column: 'f' }) &&
-        isPathEmpty(boardColorMap, { row: 8, column: 'g' }) &&
-        !wouldPositionBeChecked(boardWithoutKing, { row: 8, column: 'f' }, fromColor) &&
-        !wouldPositionBeChecked(boardWithoutKing, { row: 8, column: 'g' }, fromColor))
-    ) {
-      moves.push({ row: from.row, column: 'g', isTaken: false, isCastle: fromColor === 'white' ? 'K' : 'k' });
-    }
-    //queen side castling
-    if (
-      (fromColor === 'white' &&
+        !wouldPositionBeChecked(boardWithoutKing, { row: 1, column: 'g' }, fromColor)
+      ) {
+        moves.push({ row: from.row, column: 'g', isTaken: false, isCastle: 'K' });
+      }
+      //white queen side castling
+      if (
+        fromColor === 'white' &&
         isPathEmpty(boardColorMap, { row: 1, column: 'd' }) &&
         isPathEmpty(boardColorMap, { row: 1, column: 'c' }) &&
         isPathEmpty(boardColorMap, { row: 1, column: 'b' }) &&
-        !wouldPositionBeChecked(board, { row: 1, column: 'd' }, fromColor) &&
-        !wouldPositionBeChecked(board, { row: 1, column: 'c' }, fromColor)) ||
-      (fromColor === 'black' &&
+        !wouldPositionBeChecked(board, { row: 1, column: 'd' }, fromColor) && //not checked on d1
+        !wouldPositionBeChecked(board, { row: 1, column: 'c' }, fromColor) // not checked on c1
+      ) {
+        moves.push({ row: from.row, column: 'c', isTaken: false, isCastle: 'Q' });
+      }
+    }
+
+    if (fromColor === 'black') {
+      //black king side castling
+      if (
+        isPathEmpty(boardColorMap, { row: 8, column: 'f' }) &&
+        isPathEmpty(boardColorMap, { row: 8, column: 'g' }) &&
+        !wouldPositionBeChecked(boardWithoutKing, { row: 8, column: 'f' }, fromColor) &&
+        !wouldPositionBeChecked(boardWithoutKing, { row: 8, column: 'g' }, fromColor)
+      ) {
+        moves.push({ row: from.row, column: 'g', isTaken: false, isCastle: 'k' });
+      }
+      //black queen side castling
+      if (
+        fromColor === 'black' &&
         isPathEmpty(boardColorMap, { row: 8, column: 'd' }) &&
         isPathEmpty(boardColorMap, { row: 8, column: 'c' }) &&
         isPathEmpty(boardColorMap, { row: 8, column: 'b' }) &&
-        !wouldPositionBeChecked(board, { row: 8, column: 'd' }, fromColor) &&
-        !wouldPositionBeChecked(board, { row: 8, column: 'c' }, fromColor))
-    ) {
-      moves.push({ row: from.row, column: 'c', isTaken: false, isCastle: fromColor === 'white' ? 'Q' : 'q' });
+        !wouldPositionBeChecked(board, { row: 8, column: 'd' }, fromColor) && // would not checked on d8
+        !wouldPositionBeChecked(board, { row: 8, column: 'c' }, fromColor) // would not checked on c8
+      ) {
+        moves.push({ row: from.row, column: 'c', isTaken: false, isCastle: 'q' });
+      }
     }
+    //don't act if fromColor is none
   }
 
   return moves;

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -1,7 +1,17 @@
-import { Figure, Board, Position, Move, BoardColorMap, Color, BoardPieceMap, Direction } from './types.ts';
+import {
+  Figure,
+  Board,
+  Position,
+  Move,
+  BoardColorMap,
+  Color,
+  BoardPieceMap,
+  Direction,
+  EnPassentColumn,
+} from './types.ts';
 import { positionToCoordinate, boardToColorMap, getPieceFromPieceMap, boardToPieceMap } from './board.ts';
 import { isIndexInBound, isNil } from './helper.ts';
-import { coordinateToPosition } from './transform.ts';
+import { coordinateToPosition, enPassentColumnToIndex } from './transform.ts';
 import { isNotNil } from './helper.ts';
 import { match } from 'ts-pattern';
 import { BLACK_EN_PASSENT_ROW, SECOND_ROW, SEVENTH_ROW, WHITE_EN_PASSENT_ROW } from './constant.ts';
@@ -27,6 +37,7 @@ const isPawnCaptureBlocked = (boardToColorMap: BoardColorMap, target: Position, 
   const targetColor = extractPositionFromMap(boardToColorMap, target);
   return targetColor === 'none' || targetColor === ownColor;
 };
+
 const isPathEmpty = (boardToColorMap: BoardColorMap, target: Position) =>
   isPathBlocked(boardToColorMap, target, 'none');
 
@@ -259,7 +270,7 @@ export const calculateMoveListForKing = (
 export const calculateMoveListForPawn = (
   from: Position,
   board: Board,
-  hasPreviousTwoStepPawnMove: boolean = false, // allows en passent
+  hasPreviousTwoStepPawnMove: EnPassentColumn = '-', // allows en passent
 ): Move[] => {
   const color = board.find((square) => square.row === from.row && square.column === from.column)?.color ?? 'none';
   if (color === 'none') {
@@ -308,6 +319,7 @@ export const calculateMoveListForPawn = (
       const enpassentCapture =
         direction.col !== 0 &&
         isPathEmpty(boardColorMap, updatedPosition) &&
+        updatedColumn === enPassentColumnToIndex(hasPreviousTwoStepPawnMove) && //must be on the correct column
         hasPreviousTwoStepPawnMove &&
         ((color === 'white' && from.row === WHITE_EN_PASSENT_ROW) ||
           (color === 'black' && from.row === BLACK_EN_PASSENT_ROW)); //pawn must be on 5th (white) or 4th (black) row
@@ -347,7 +359,7 @@ export const calculateMoveListForPawn = (
 export const calculateMoveListForPiece = (
   from: Position,
   board: Board,
-  hasPreviousTwoStepPawnMove: boolean = false, // is true if pawn was moved two squares in the last move
+  hasPreviousTwoStepPawnMove: EnPassentColumn = '-', // is true if pawn was moved two squares in the last move
 ): Move[] => {
   const piece = board.find((square) => square.row === from.row && square.column === from.column);
   if (isNil(piece)) {

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -156,6 +156,8 @@ export const calculateMoveListForQueen = (from: Position, board: Board): Move[] 
   return moveDirection(directions, from, moves, board);
 };
 
+
+
 export const calculateMoveListForKing = (
   from: Position,
   board: Board,
@@ -167,7 +169,7 @@ export const calculateMoveListForKing = (
   const pieceMap = boardToPieceMap(board);
   const boardColorMap = pieceMap.map((row) => row.map((piece) => (isNil(piece) ? 'none' : piece.color)));
   const color = extractColorFromMap(boardColorMap, from);
-  const boardWithoutKing = board.filter((piece) => piece.row !== from.row && piece.column !== from.column);
+  const boardWithoutKing = board.filter((square) => !(square.figure === 'KING' && square.color === color)); //remove own king from board to avoid blocking the algorithm
 
   const kingMoves = [
     { row: 1, col: 0 },
@@ -183,21 +185,17 @@ export const calculateMoveListForKing = (
   kingMoves.map((move) => {
     const updatedRow = current[0] + move.row;
     const updatedCol = current[1] + move.col;
-    const updatedPos = coordinateToPosition(updatedCol, updatedRow);
     const isInBound = isIndexInBound(updatedRow) && isIndexInBound(updatedCol);
     if (isInBound) {
       //only add move if king will not be in check!
       // <=> king is not touching other king
-      const updatedPosIsThreat = wouldPositionBeChecked(
-        //remove king from board to avoid blocking the algorithm
-        boardWithoutKing,
-        updatedPos,
-        color,
-      );
+      const updatedPos = coordinateToPosition(updatedCol, updatedRow);
+      //remove king from board to avoid blocking the algorithm
+      const updatedPosIsThreatened = wouldPositionBeChecked(boardWithoutKing, updatedPos, color);
 
       //only add move if path isn't blocked by own piece
       //and if new position is not threatened by opponent piece
-      if (!isPathBlocked(boardColorMap, updatedPos, color) && !updatedPosIsThreat) {
+      if (!isPathBlocked(boardColorMap, updatedPos, color) && !updatedPosIsThreatened) {
         moves.push({ ...updatedPos, isTaken: isPieceCaptured(boardColorMap, updatedPos, color) });
       }
     }

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -217,8 +217,10 @@ export const calculateMoveListForKing = (
   const fromColor = extractColorFromMap(boardColorMap, from);
   if (isCastlingPossible && !isKingChecked) {
     if (fromColor === 'white') {
+      const isCorrectPosition = from.row === 1 && from.column === 'e';
       //white king side castling
       if (
+        isCorrectPosition &&
         isPathEmpty(boardColorMap, { row: 1, column: 'f' }) &&
         isPathEmpty(boardColorMap, { row: 1, column: 'g' }) &&
         !wouldPositionBeChecked(boardWithoutKing, { row: 1, column: 'f' }, fromColor) &&
@@ -228,6 +230,7 @@ export const calculateMoveListForKing = (
       }
       //white queen side castling
       if (
+        isCorrectPosition &&
         fromColor === 'white' &&
         isPathEmpty(boardColorMap, { row: 1, column: 'd' }) &&
         isPathEmpty(boardColorMap, { row: 1, column: 'c' }) &&
@@ -240,8 +243,10 @@ export const calculateMoveListForKing = (
     }
 
     if (fromColor === 'black') {
+      const isCorrectPosition = from.row === 8 && from.column === 'e';
       //black king side castling
       if (
+        isCorrectPosition &&
         isPathEmpty(boardColorMap, { row: 8, column: 'f' }) &&
         isPathEmpty(boardColorMap, { row: 8, column: 'g' }) &&
         !wouldPositionBeChecked(boardWithoutKing, { row: 8, column: 'f' }, fromColor) &&
@@ -251,7 +256,7 @@ export const calculateMoveListForKing = (
       }
       //black queen side castling
       if (
-        fromColor === 'black' &&
+        isCorrectPosition &&
         isPathEmpty(boardColorMap, { row: 8, column: 'd' }) &&
         isPathEmpty(boardColorMap, { row: 8, column: 'c' }) &&
         isPathEmpty(boardColorMap, { row: 8, column: 'b' }) &&

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -467,8 +467,24 @@ export const isKingChecked = (board: Board, color: Color): boolean => {
   }
 };
 
-export const isCheckMate = (
-  board: Board,
-  color: Color,
-): boolean => //king has no moves.. and is checked
-  calculateMoveListForKing(findKingPosition(board, color)!, board).length === 0 && isKingChecked(board, color);
+export const isCheckMate = (board: Board, color: Color): boolean => {
+  //king has no moves.. and is checked
+  const position = findKingPosition(board, color);
+  if (position === undefined) {
+    throw new Error('King not found on the board');
+  } else {
+    return calculateMoveListForKing(position, board).length === 0 && isKingChecked(board, color);
+  }
+};
+
+export const isStaleMate = (board: Board, color: Color): boolean => {
+  //king has no moves.. and is not checked
+  //king has no moves.. and is checked
+  const position = findKingPosition(board, color);
+  if (position === undefined) {
+    throw new Error('King not found on the board');
+  } else {
+    return calculateMoveListForKing(position, board).length === 0 && !isKingChecked(board, color);
+  }
+};
+

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -1,5 +1,5 @@
 import { isKingChecked } from './check.ts';
-import { Board, Position, Move, BoardColorMap, Color, Direction, EnPassentColumn, BoardPieceMap } from './types.ts';
+import { Board, Position, Move, BoardColorMap, Color, Direction, EnPassentColumn } from './types.ts';
 import { positionToCoordinate, boardToColorMap, boardToPieceMap, boardPieceMapToColorMap } from './board.ts';
 import { isIndexInBound, isNil } from './helper.ts';
 import { coordinateToPosition, enPassentColumnToIndex } from './transform.ts';
@@ -165,6 +165,8 @@ export const calculateMoveListForKing = (
   const current = positionToCoordinate(from);
   const pieceMap = boardToPieceMap(board);
   const boardColorMap = pieceMap.map((row) => row.map((piece) => (isNil(piece) ? 'none' : piece.color)));
+  const color = extractColorFromMap(boardColorMap, from);
+
   const kingMoves = [
     { row: 1, col: 0 },
     { row: -1, col: 0 },
@@ -182,17 +184,33 @@ export const calculateMoveListForKing = (
     const updatedPos = coordinateToPosition(updatedCol, updatedRow);
     const isInBound = isIndexInBound(updatedRow) && isIndexInBound(updatedCol);
     if (isInBound) {
-      if (!isPathBlocked(boardColorMap, updatedPos, extractColorFromMap(boardColorMap, from))) {
-        moves.push({
-          ...updatedPos,
-          isTaken: isPieceCaptured(boardColorMap, updatedPos, extractColorFromMap(boardColorMap, from)),
-        });
+      //only add move if king will not be in check!
+      // <=> king is not touching other king
+
+      //only add move if path isn't blocked by own piece
+      if (!isPathBlocked(boardColorMap, updatedPos, color)) {
+        moves.push({ ...updatedPos, isTaken: isPieceCaptured(boardColorMap, updatedPos, color) });
       }
     }
   });
   //castling logic
+  //evaluated externally:
+  //king has moved, prevents color castling
+  //white left rook moved, prevents white queen side castle
+  //white right rook moved, prevents white king side castle
+  //black right rook moved, prevents black king side castle
+  //black left rook moved, prevents black queen side castle
+
+  //evaluate following conditions:
+  //path between rook and king is empty
+  //king isn't in check
+  //king wouldn't be in check after castling (also the square the king passes over)
+
+  const fromColor = extractColorFromMap(boardColorMap, from);
   if (isCastlingPossible && !isKingChecked(board, extractColorFromMap(boardColorMap, from))) {
-    //
+    // if(fromColor === 'white') {
+    // } else {
+    // }
   }
 
   return moves;

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -301,14 +301,8 @@ export const calculateMoveListForKing = (
 //   }
 // };
 
-export const calculateMoveListForPawn = (
-  from: Position,
-  board: Board,
-  enPassentPossible: boolean = false,
-): Move[] => {
-  const color = board.find(
-    (square) => square.row === from.row && square.column === from.column,
-  )?.color;
+export const calculateMoveListForPawn = (from: Position, board: Board, isEnPassentPossible: boolean = false): Move[] => {
+  const color = board.find((square) => square.row === from.row && square.column === from.column)?.color;
   if (isNil(color) || color === 'none') {
     throw new Error('No piece found at the given position or invalid color');
   }
@@ -328,8 +322,7 @@ export const calculateMoveListForPawn = (
     { row: -1, col: 1 }, //capture right
     { row: -1, col: -1 }, //capture left
   ];
-  const directions =
-    color === 'white' ? whitePawnDirections : blackPawnDirections;
+  const directions = color === 'white' ? whitePawnDirections : blackPawnDirections;
   const moves: Move[] = [];
 
   directions.map((direction) => {
@@ -338,24 +331,25 @@ export const calculateMoveListForPawn = (
     const updatedRow = current[0] * direction.row; //y
     const updatedColumn = current[1] * direction.col; //x
     if (
-      isIndexInBound(updatedRow) &&
-      isIndexInBound(updatedColumn) &&
-      color !== undefined &&
-      !isPathBlocked(
-        //own color isn't other piece color
-        boardToColorMap(board),
-        coordinateToPosition(updatedColumn, updatedRow),
-        color,
-      ) &&
-      direction.col === 0 //forward move, no capture
-    ) {
-      moves.push({
-        ...coordinateToPosition(updatedColumn, updatedRow),
-        isTaken: isPieceTaken(
+      (isIndexInBound(updatedRow) &&
+        isIndexInBound(updatedColumn) &&
+        color !== undefined &&
+        ((!isPathBlocked(
+          //own color isn't other piece color
           boardToColorMap(board),
           coordinateToPosition(updatedColumn, updatedRow),
           color,
-        ),
+        ) &&
+          direction.col !== 0) ||
+          (direction.col === 0 &&
+            isPathEmpty(boardToColorMap(board), coordinateToPosition(updatedColumn, updatedRow))))) || //forward move, no capture
+      (direction.col !== 0 &&
+        isPathEmpty(boardToColorMap(board), coordinateToPosition(updatedColumn, updatedRow)) &&
+        isEnPassentPossible) //en passent move)
+    ) {
+      moves.push({
+        ...coordinateToPosition(updatedColumn, updatedRow),
+        isTaken: isPieceTaken(boardToColorMap(board), coordinateToPosition(updatedColumn, updatedRow), color ?? 'none'),
       });
     }
   });

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -1,0 +1,518 @@
+import {
+  Figure,
+  Board,
+  Position,
+  Move,
+  BoardColorMap,
+  Color,
+  BoardPieceMap,
+} from './types.ts';
+import {
+  positionToCoordinate,
+  boardToColorMap,
+  getPieceFromPieceMap,
+  boardToPieceMap,
+} from './board.ts';
+import { isIndexInBound, isNil } from './helper.ts';
+import { coordinateToPosition } from './transform.ts';
+import { isNotNil } from './helper.ts';
+import { match } from 'ts-pattern';
+
+const extractPositionFromMap = (
+  boardColorMap: BoardColorMap,
+  target: Position,
+): Color => {
+  const targetCoord = positionToCoordinate(target);
+  const row = boardColorMap[targetCoord[1]] ?? [];
+  return row[targetCoord[0]] ?? 'none';
+};
+
+const isPieceTaken = (
+  boardColorMap: BoardColorMap,
+  target: Position,
+  ownColor: Color,
+): boolean => {
+  //a piece gets taken when the target position is occupied by an opponent piece
+  const targetColor = extractPositionFromMap(boardColorMap, target);
+
+  return targetColor !== 'none' && targetColor !== ownColor;
+};
+const isPathBlocked = (
+  boardColorMap: BoardColorMap,
+  target: Position,
+  ownColor: Color,
+): boolean => {
+  //a piece gets taken when the target position is occupied by an opponent piece
+  const targetColor = extractPositionFromMap(boardColorMap, target);
+
+  return targetColor === ownColor;
+};
+const isPathEmpty = (boardToColorMap: BoardColorMap, target: Position) =>
+  isPathBlocked(boardToColorMap, target, 'none');
+
+export const calculateMoveListForBishop = (
+  from: Position,
+  board: Board,
+): Move[] => {
+  const moves: Move[] = [];
+  const current = positionToCoordinate(from);
+  const boardColorMap = boardToColorMap(board);
+  const directions = [
+    { row: 1, col: 1 },
+    { row: 1, col: -1 },
+    { row: -1, col: 1 },
+    { row: -1, col: -1 },
+  ] as const;
+  directions.map((direction) => {
+    let step = 1;
+    while (step < 8) {
+      //maybe use range here?..how to break then.. return..
+      const updatedRow = current[0] + direction.row * step;
+      const updatedCol = current[1] + direction.col * step;
+      const pathBlocked = isPathBlocked(
+        boardColorMap,
+        coordinateToPosition(updatedCol, updatedRow),
+        extractPositionFromMap(boardColorMap, from),
+      );
+      if (
+        isIndexInBound(updatedRow) &&
+        isIndexInBound(updatedCol) &&
+        !pathBlocked
+      ) {
+        moves.push({
+          ...coordinateToPosition(updatedCol, updatedRow),
+          isTaken: isPieceTaken(
+            boardColorMap,
+            coordinateToPosition(updatedCol, updatedRow),
+            extractPositionFromMap(boardColorMap, from),
+          ),
+        });
+      } else {
+        break;
+      }
+      if (pathBlocked) {
+        break;
+      }
+
+      ++step;
+    }
+  });
+  return moves;
+};
+
+export const calculateMoveListForKnight = (
+  from: Position,
+  board: Board,
+): Move[] => {
+  const moves: Move[] = [];
+  const current = positionToCoordinate(from);
+  const boardColorMap = boardToColorMap(board);
+  const knightMoves = [
+    { row: 2, col: 1 },
+    { row: 2, col: -1 },
+    { row: -2, col: 1 },
+    { row: -2, col: -1 },
+    { row: 1, col: 2 },
+    { row: 1, col: -2 },
+    { row: -1, col: 2 },
+    { row: -1, col: -2 },
+  ] as const;
+
+  knightMoves.map((move) => {
+    const updatedRow = current[0] + move.row;
+    const updatedCol = current[1] + move.col;
+    if (
+      isIndexInBound(updatedRow) &&
+      isIndexInBound(updatedCol) &&
+      !isPathBlocked(
+        boardColorMap,
+        coordinateToPosition(updatedCol, updatedRow),
+        extractPositionFromMap(boardColorMap, from),
+      )
+    ) {
+      moves.push({
+        ...coordinateToPosition(updatedCol, updatedRow),
+        isTaken: isPieceTaken(
+          boardColorMap,
+          coordinateToPosition(updatedCol, updatedRow),
+          extractPositionFromMap(boardColorMap, from),
+        ),
+      });
+    }
+  });
+
+  return moves;
+};
+
+export const calculateMoveListForRook = (
+  from: Position,
+  board: Board,
+): Move[] => {
+  const moves: Move[] = [];
+  const current = positionToCoordinate(from);
+  const boardColorMap = boardToColorMap(board);
+  const directions = [
+    { row: 1, col: 0 },
+    { row: -1, col: 0 },
+    { row: 0, col: 1 },
+    { row: 0, col: -1 },
+  ] as const;
+  directions.map((direction) => {
+    let step = 1;
+    while (step < 8) {
+      //maybe use range here?..how to break then.. return..
+      const updatedRow = current[0] + direction.row * step;
+      const updatedCol = current[1] + direction.col * step;
+      const pathBlocked = isPathBlocked(
+        boardColorMap,
+        coordinateToPosition(updatedCol, updatedRow),
+        extractPositionFromMap(boardColorMap, from),
+      );
+      if (
+        isIndexInBound(updatedRow) &&
+        isIndexInBound(updatedCol) &&
+        !pathBlocked
+      ) {
+        moves.push({
+          ...coordinateToPosition(updatedCol, updatedRow),
+          isTaken: isPieceTaken(
+            boardColorMap,
+            coordinateToPosition(updatedCol, updatedRow),
+            extractPositionFromMap(boardColorMap, from),
+          ),
+        });
+      } else {
+        break;
+      }
+      if (pathBlocked) {
+        break;
+      }
+
+      ++step;
+    }
+  });
+  return moves;
+};
+
+export const calculateMoveListForQueen = (
+  from: Position,
+  board: Board,
+): Move[] => {
+  const moves: Move[] = [];
+  const current = positionToCoordinate(from);
+  const boardColorMap = boardToColorMap(board);
+  const directions = [
+    { row: 1, col: 0 },
+    { row: -1, col: 0 },
+    { row: 0, col: 1 },
+    { row: 0, col: -1 },
+    { row: 1, col: 1 },
+    { row: 1, col: -1 },
+    { row: -1, col: 1 },
+    { row: -1, col: -1 },
+  ] as const;
+  directions.map((direction) => {
+    let step = 1;
+    while (step < 8) {
+      //this could be optimized by extracting common logic with rook and bishop
+      //it's repeated code
+      //maybe extract this later to a helper function
+      const updatedRow = current[0] + direction.row * step;
+      const updatedCol = current[1] + direction.col * step;
+      const pathBlocked = isPathBlocked(
+        boardColorMap,
+        coordinateToPosition(updatedCol, updatedRow),
+        extractPositionFromMap(boardColorMap, from),
+      );
+      if (
+        isIndexInBound(updatedRow) &&
+        isIndexInBound(updatedCol) &&
+        !pathBlocked
+      ) {
+        moves.push({
+          ...coordinateToPosition(updatedCol, updatedRow),
+          isTaken: isPieceTaken(
+            boardColorMap,
+            coordinateToPosition(updatedCol, updatedRow),
+            extractPositionFromMap(boardColorMap, from),
+          ),
+        });
+      } else {
+        break;
+      }
+      if (pathBlocked) {
+        break;
+      }
+
+      ++step;
+    }
+  });
+  return moves;
+};
+
+export const calculateMoveListForKing = (
+  from: Position,
+  board: Board,
+): Move[] => {
+  const moves: Move[] = [];
+  const current = positionToCoordinate(from);
+  const boardColorMap = boardToColorMap(board);
+  const kingMoves = [
+    { row: 1, col: 0 },
+    { row: -1, col: 0 },
+    { row: 0, col: 1 },
+    { row: 0, col: -1 },
+    { row: 1, col: 1 },
+    { row: 1, col: -1 },
+    { row: -1, col: 1 },
+    { row: -1, col: -1 },
+  ] as const;
+
+  kingMoves.map((move) => {
+    const updatedRow = current[0] + move.row;
+    const updatedCol = current[1] + move.col;
+    if (
+      isIndexInBound(updatedRow) &&
+      isIndexInBound(updatedCol) &&
+      !isPathBlocked(
+        boardColorMap,
+        coordinateToPosition(updatedCol, updatedRow),
+        extractPositionFromMap(boardColorMap, from),
+      )
+    ) {
+      moves.push({
+        ...coordinateToPosition(updatedCol, updatedRow),
+        isTaken: isPieceTaken(
+          boardColorMap,
+          coordinateToPosition(updatedCol, updatedRow),
+          extractPositionFromMap(boardColorMap, from),
+        ),
+      });
+    }
+  });
+
+  return moves;
+};
+
+// const checkForEnpassent = (from: Position, color: Color): Position | null => {
+//   if (color === 'white' && from.row === 'e') {
+//     //check whether pawn is to the left or right
+//     return { row: 6, column: from.column };
+//   }
+// };
+
+export const calculateMoveListForPawn = (
+  from: Position,
+  board: Board,
+  enPassentPossible: boolean = false,
+): Move[] => {
+  const color = board.find(
+    (square) => square.row === from.row && square.column === from.column,
+  )?.color;
+  if (isNil(color) || color === 'none') {
+    throw new Error('No piece found at the given position or invalid color');
+  }
+  const whitePawnDirections: {
+    row: number;
+    col: number;
+  }[] = [
+    { row: 1, col: 0 }, //forward
+    { row: 1, col: 1 }, //capture right
+    { row: 1, col: -1 }, //capture left
+  ];
+  const blackPawnDirections: {
+    row: number;
+    col: number;
+  }[] = [
+    { row: -1, col: 0 }, //forward
+    { row: -1, col: 1 }, //capture right
+    { row: -1, col: -1 }, //capture left
+  ];
+  const directions =
+    color === 'white' ? whitePawnDirections : blackPawnDirections;
+  const moves: Move[] = [];
+
+  directions.map((direction) => {
+    const current = positionToCoordinate(from);
+
+    const updatedRow = current[0] * direction.row; //y
+    const updatedColumn = current[1] * direction.col; //x
+    if (
+      isIndexInBound(updatedRow) &&
+      isIndexInBound(updatedColumn) &&
+      color !== undefined &&
+      !isPathBlocked(
+        //own color isn't other piece color
+        boardToColorMap(board),
+        coordinateToPosition(updatedColumn, updatedRow),
+        color,
+      ) &&
+      direction.col === 0 //forward move, no capture
+    ) {
+      moves.push({
+        ...coordinateToPosition(updatedColumn, updatedRow),
+        isTaken: isPieceTaken(
+          boardToColorMap(board),
+          coordinateToPosition(updatedColumn, updatedRow),
+          color,
+        ),
+      });
+    }
+  });
+  return moves;
+};
+
+export const calculateMoveListForPiece = (
+  from: Position,
+  board: Board,
+): Move[] => {
+  const piece = board.find(
+    (square) => square.row === from.row && square.column === from.column,
+  );
+  if (isNil(piece)) {
+    throw new Error('No piece found at the given position');
+  }
+
+  return match(piece?.figure)
+    .with('BISHOP', () => calculateMoveListForBishop(from, board))
+    .with('KNIGHT', () => calculateMoveListForKnight(from, board))
+    .with('ROOK', () => calculateMoveListForRook(from, board))
+    .with('QUEEN', () => calculateMoveListForQueen(from, board))
+    .with('KING', () => calculateMoveListForKing(from, board))
+    .with('PAWN', () => {
+      throw new Error('Pawn move calculation not implemented yet');
+    })
+    .otherwise(() => {
+      throw new Error('Invalid piece type');
+    });
+};
+
+const findKingPosition = (board: Board, color: Color): Position | undefined => {
+  const kingSquare = board.find(
+    (square) => square.figure === 'KING' && square.color === color,
+  );
+  return kingSquare
+    ? { row: kingSquare.row, column: kingSquare.column }
+    : undefined;
+};
+
+const isPawnDirectionCorrect = (
+  direction: { row: number; col: number },
+  color: Color,
+) =>
+  (color === 'white' && direction.row === 1) ||
+  (color === 'black' && direction.row === -1);
+
+const checkDirectionForCheck = (
+  pieceMap: BoardPieceMap,
+  kingPosition: Position | undefined,
+  directions: readonly { row: number; col: number }[],
+  color: Color,
+  targetFigures: Figure[],
+  siftBoard: boolean = true,
+) => {
+  directions.map((direction) => {
+    let step = siftBoard ? 1 : 7;
+    while (step < 8 && isNotNil(kingPosition)) {
+      //maybe a better way instead of using typeguard
+      const stepTemp = siftBoard ? step : 1;
+
+      const updatedRow =
+        positionToCoordinate(kingPosition)[0] + direction.row * stepTemp;
+      const updatedCol =
+        positionToCoordinate(kingPosition)[1] + direction.col * stepTemp;
+      const piece = getPieceFromPieceMap(
+        pieceMap,
+        coordinateToPosition(updatedCol, updatedRow),
+      );
+      if (piece !== null) {
+        if (
+          //check for pawn attack
+          step === 1 &&
+          piece.figure === 'PAWN' &&
+          targetFigures.includes('BISHOP') &&
+          piece.color !== color &&
+          isPawnDirectionCorrect(direction, piece.color)
+        ) {
+          return true;
+        }
+
+        if (piece.color !== color && targetFigures.includes(piece.figure)) {
+          return true;
+        }
+        break; //blocked by own piece or opponent piece
+      }
+      //found piece in this direction
+      ++step;
+    }
+  });
+  return false;
+};
+
+const isKingChecked = (board: Board, color: Color): boolean => {
+  const pieceMap = boardToPieceMap(board);
+  const kingPosition = findKingPosition(board, color);
+  if (isNil(kingPosition)) {
+    throw new Error('King not found on the board');
+  } else {
+    const bishopDirection = [
+      { row: 1, col: 1 },
+      { row: 1, col: -1 },
+      { row: -1, col: 1 },
+      { row: -1, col: -1 },
+    ] as const;
+    const rookDirection = [
+      { row: 1, col: 0 },
+      { row: -1, col: 0 },
+      { row: 0, col: 1 },
+      { row: 0, col: -1 },
+    ] as const;
+    //check by knight
+    const knightMoves = [
+      { row: 2, col: 1 },
+      { row: 2, col: -1 },
+      { row: -2, col: 1 },
+      { row: -2, col: -1 },
+      { row: 1, col: 2 },
+      { row: 1, col: -2 },
+      { row: -1, col: 2 },
+      { row: -1, col: -2 },
+    ] as const;
+
+    if (
+      checkDirectionForCheck(pieceMap, kingPosition, bishopDirection, color, [
+        'BISHOP',
+        'QUEEN',
+      ])
+    )
+      return true;
+    //check by bishop or queen
+    //check by rook or queen
+    if (
+      checkDirectionForCheck(pieceMap, kingPosition, rookDirection, color, [
+        'ROOK',
+        'QUEEN',
+      ])
+    )
+      return true;
+    if (
+      checkDirectionForCheck(
+        pieceMap,
+        kingPosition,
+        knightMoves,
+        color,
+        ['KNIGHT'],
+        false,
+      )
+    )
+      return true;
+    return false;
+  }
+};
+
+export const isCheckMate = (
+  board: Board,
+  color: Color,
+): boolean => //king has no moves.. and is checked
+  calculateMoveListForKing(findKingPosition(board, color)!, board).length ===
+    0 && isKingChecked(board, color);

--- a/src/geometry/move.ts
+++ b/src/geometry/move.ts
@@ -1,47 +1,23 @@
-import {
-  Figure,
-  Board,
-  Position,
-  Move,
-  BoardColorMap,
-  Color,
-  BoardPieceMap,
-} from './types.ts';
-import {
-  positionToCoordinate,
-  boardToColorMap,
-  getPieceFromPieceMap,
-  boardToPieceMap,
-} from './board.ts';
+import { Figure, Board, Position, Move, BoardColorMap, Color, BoardPieceMap } from './types.ts';
+import { positionToCoordinate, boardToColorMap, getPieceFromPieceMap, boardToPieceMap } from './board.ts';
 import { isIndexInBound, isNil } from './helper.ts';
 import { coordinateToPosition } from './transform.ts';
 import { isNotNil } from './helper.ts';
 import { match } from 'ts-pattern';
 
-const extractPositionFromMap = (
-  boardColorMap: BoardColorMap,
-  target: Position,
-): Color => {
+const extractPositionFromMap = (boardColorMap: BoardColorMap, target: Position): Color => {
   const targetCoord = positionToCoordinate(target);
   const row = boardColorMap[targetCoord[1]] ?? [];
   return row[targetCoord[0]] ?? 'none';
 };
 
-const isPieceTaken = (
-  boardColorMap: BoardColorMap,
-  target: Position,
-  ownColor: Color,
-): boolean => {
+const isPieceTaken = (boardColorMap: BoardColorMap, target: Position, ownColor: Color): boolean => {
   //a piece gets taken when the target position is occupied by an opponent piece
   const targetColor = extractPositionFromMap(boardColorMap, target);
 
   return targetColor !== 'none' && targetColor !== ownColor;
 };
-const isPathBlocked = (
-  boardColorMap: BoardColorMap,
-  target: Position,
-  ownColor: Color,
-): boolean => {
+const isPathBlocked = (boardColorMap: BoardColorMap, target: Position, ownColor: Color): boolean => {
   //a piece gets taken when the target position is occupied by an opponent piece
   const targetColor = extractPositionFromMap(boardColorMap, target);
 
@@ -50,10 +26,7 @@ const isPathBlocked = (
 const isPathEmpty = (boardToColorMap: BoardColorMap, target: Position) =>
   isPathBlocked(boardToColorMap, target, 'none');
 
-export const calculateMoveListForBishop = (
-  from: Position,
-  board: Board,
-): Move[] => {
+export const calculateMoveListForBishop = (from: Position, board: Board): Move[] => {
   const moves: Move[] = [];
   const current = positionToCoordinate(from);
   const boardColorMap = boardToColorMap(board);
@@ -74,11 +47,7 @@ export const calculateMoveListForBishop = (
         coordinateToPosition(updatedCol, updatedRow),
         extractPositionFromMap(boardColorMap, from),
       );
-      if (
-        isIndexInBound(updatedRow) &&
-        isIndexInBound(updatedCol) &&
-        !pathBlocked
-      ) {
+      if (isIndexInBound(updatedRow) && isIndexInBound(updatedCol) && !pathBlocked) {
         moves.push({
           ...coordinateToPosition(updatedCol, updatedRow),
           isTaken: isPieceTaken(
@@ -100,10 +69,7 @@ export const calculateMoveListForBishop = (
   return moves;
 };
 
-export const calculateMoveListForKnight = (
-  from: Position,
-  board: Board,
-): Move[] => {
+export const calculateMoveListForKnight = (from: Position, board: Board): Move[] => {
   const moves: Move[] = [];
   const current = positionToCoordinate(from);
   const boardColorMap = boardToColorMap(board);
@@ -144,10 +110,7 @@ export const calculateMoveListForKnight = (
   return moves;
 };
 
-export const calculateMoveListForRook = (
-  from: Position,
-  board: Board,
-): Move[] => {
+export const calculateMoveListForRook = (from: Position, board: Board): Move[] => {
   const moves: Move[] = [];
   const current = positionToCoordinate(from);
   const boardColorMap = boardToColorMap(board);
@@ -168,11 +131,7 @@ export const calculateMoveListForRook = (
         coordinateToPosition(updatedCol, updatedRow),
         extractPositionFromMap(boardColorMap, from),
       );
-      if (
-        isIndexInBound(updatedRow) &&
-        isIndexInBound(updatedCol) &&
-        !pathBlocked
-      ) {
+      if (isIndexInBound(updatedRow) && isIndexInBound(updatedCol) && !pathBlocked) {
         moves.push({
           ...coordinateToPosition(updatedCol, updatedRow),
           isTaken: isPieceTaken(
@@ -194,10 +153,7 @@ export const calculateMoveListForRook = (
   return moves;
 };
 
-export const calculateMoveListForQueen = (
-  from: Position,
-  board: Board,
-): Move[] => {
+export const calculateMoveListForQueen = (from: Position, board: Board): Move[] => {
   const moves: Move[] = [];
   const current = positionToCoordinate(from);
   const boardColorMap = boardToColorMap(board);
@@ -224,11 +180,7 @@ export const calculateMoveListForQueen = (
         coordinateToPosition(updatedCol, updatedRow),
         extractPositionFromMap(boardColorMap, from),
       );
-      if (
-        isIndexInBound(updatedRow) &&
-        isIndexInBound(updatedCol) &&
-        !pathBlocked
-      ) {
+      if (isIndexInBound(updatedRow) && isIndexInBound(updatedCol) && !pathBlocked) {
         moves.push({
           ...coordinateToPosition(updatedCol, updatedRow),
           isTaken: isPieceTaken(
@@ -250,10 +202,7 @@ export const calculateMoveListForQueen = (
   return moves;
 };
 
-export const calculateMoveListForKing = (
-  from: Position,
-  board: Board,
-): Move[] => {
+export const calculateMoveListForKing = (from: Position, board: Board): Move[] => {
   const moves: Move[] = [];
   const current = positionToCoordinate(from);
   const boardColorMap = boardToColorMap(board);
@@ -294,14 +243,11 @@ export const calculateMoveListForKing = (
   return moves;
 };
 
-// const checkForEnpassent = (from: Position, color: Color): Position | null => {
-//   if (color === 'white' && from.row === 'e') {
-//     //check whether pawn is to the left or right
-//     return { row: 6, column: from.column };
-//   }
-// };
-
-export const calculateMoveListForPawn = (from: Position, board: Board, isEnPassentPossible: boolean = false): Move[] => {
+export const calculateMoveListForPawn = (
+  from: Position,
+  board: Board,
+  isEnPassentPossible: boolean = false, // is true if pawn was moved two squares in the last move
+): Move[] => {
   const color = board.find((square) => square.row === from.row && square.column === from.column)?.color;
   if (isNil(color) || color === 'none') {
     throw new Error('No piece found at the given position or invalid color');
@@ -345,7 +291,7 @@ export const calculateMoveListForPawn = (from: Position, board: Board, isEnPasse
             isPathEmpty(boardToColorMap(board), coordinateToPosition(updatedColumn, updatedRow))))) || //forward move, no capture
       (direction.col !== 0 &&
         isPathEmpty(boardToColorMap(board), coordinateToPosition(updatedColumn, updatedRow)) &&
-        isEnPassentPossible) //en passent move)
+        isEnPassentPossible) //check for en passent move
     ) {
       moves.push({
         ...coordinateToPosition(updatedColumn, updatedRow),
@@ -359,10 +305,9 @@ export const calculateMoveListForPawn = (from: Position, board: Board, isEnPasse
 export const calculateMoveListForPiece = (
   from: Position,
   board: Board,
+  isEnPassentPossible: boolean = false, // is true if pawn was moved two squares in the last move
 ): Move[] => {
-  const piece = board.find(
-    (square) => square.row === from.row && square.column === from.column,
-  );
+  const piece = board.find((square) => square.row === from.row && square.column === from.column);
   if (isNil(piece)) {
     throw new Error('No piece found at the given position');
   }
@@ -373,29 +318,19 @@ export const calculateMoveListForPiece = (
     .with('ROOK', () => calculateMoveListForRook(from, board))
     .with('QUEEN', () => calculateMoveListForQueen(from, board))
     .with('KING', () => calculateMoveListForKing(from, board))
-    .with('PAWN', () => {
-      throw new Error('Pawn move calculation not implemented yet');
-    })
+    .with('PAWN', () => calculateMoveListForPawn(from, board, isEnPassentPossible))
     .otherwise(() => {
       throw new Error('Invalid piece type');
     });
 };
 
 const findKingPosition = (board: Board, color: Color): Position | undefined => {
-  const kingSquare = board.find(
-    (square) => square.figure === 'KING' && square.color === color,
-  );
-  return kingSquare
-    ? { row: kingSquare.row, column: kingSquare.column }
-    : undefined;
+  const kingSquare = board.find((square) => square.figure === 'KING' && square.color === color);
+  return kingSquare ? { row: kingSquare.row, column: kingSquare.column } : undefined;
 };
 
-const isPawnDirectionCorrect = (
-  direction: { row: number; col: number },
-  color: Color,
-) =>
-  (color === 'white' && direction.row === 1) ||
-  (color === 'black' && direction.row === -1);
+const isPawnDirectionCorrect = (direction: { row: number; col: number }, color: Color) =>
+  (color === 'white' && direction.row === 1) || (color === 'black' && direction.row === -1);
 
 const checkDirectionForCheck = (
   pieceMap: BoardPieceMap,
@@ -411,14 +346,9 @@ const checkDirectionForCheck = (
       //maybe a better way instead of using typeguard
       const stepTemp = siftBoard ? step : 1;
 
-      const updatedRow =
-        positionToCoordinate(kingPosition)[0] + direction.row * stepTemp;
-      const updatedCol =
-        positionToCoordinate(kingPosition)[1] + direction.col * stepTemp;
-      const piece = getPieceFromPieceMap(
-        pieceMap,
-        coordinateToPosition(updatedCol, updatedRow),
-      );
+      const updatedRow = positionToCoordinate(kingPosition)[0] + direction.row * stepTemp;
+      const updatedCol = positionToCoordinate(kingPosition)[1] + direction.col * stepTemp;
+      const piece = getPieceFromPieceMap(pieceMap, coordinateToPosition(updatedCol, updatedRow));
       if (piece !== null) {
         if (
           //check for pawn attack
@@ -473,33 +403,11 @@ const isKingChecked = (board: Board, color: Color): boolean => {
       { row: -1, col: -2 },
     ] as const;
 
-    if (
-      checkDirectionForCheck(pieceMap, kingPosition, bishopDirection, color, [
-        'BISHOP',
-        'QUEEN',
-      ])
-    )
-      return true;
+    if (checkDirectionForCheck(pieceMap, kingPosition, bishopDirection, color, ['BISHOP', 'QUEEN'])) return true;
     //check by bishop or queen
     //check by rook or queen
-    if (
-      checkDirectionForCheck(pieceMap, kingPosition, rookDirection, color, [
-        'ROOK',
-        'QUEEN',
-      ])
-    )
-      return true;
-    if (
-      checkDirectionForCheck(
-        pieceMap,
-        kingPosition,
-        knightMoves,
-        color,
-        ['KNIGHT'],
-        false,
-      )
-    )
-      return true;
+    if (checkDirectionForCheck(pieceMap, kingPosition, rookDirection, color, ['ROOK', 'QUEEN'])) return true;
+    if (checkDirectionForCheck(pieceMap, kingPosition, knightMoves, color, ['KNIGHT'], false)) return true;
     return false;
   }
 };
@@ -508,5 +416,4 @@ export const isCheckMate = (
   board: Board,
   color: Color,
 ): boolean => //king has no moves.. and is checked
-  calculateMoveListForKing(findKingPosition(board, color)!, board).length ===
-    0 && isKingChecked(board, color);
+  calculateMoveListForKing(findKingPosition(board, color)!, board).length === 0 && isKingChecked(board, color);

--- a/src/geometry/pgn.ts
+++ b/src/geometry/pgn.ts
@@ -1,0 +1,6 @@
+import { Move } from './types.ts';
+
+const moveToPgnString = (move: Move): string => {
+  const pieceChar = move.isTaken ? 'x' : '-';
+  return `${move.row}${pieceChar}${move.column}`;
+};

--- a/src/geometry/print.ts
+++ b/src/geometry/print.ts
@@ -1,27 +1,27 @@
-import { Board, Square } from './types.ts';
-import { figureToLetter } from './board.ts';
-export const printBoard = (board: Board): void => {
-  const rows: string[] = Array(8).fill('');
-  board.forEach((square) => {
-    const rowIndex = 8 - square.column;
-    const colIndex = square.row.charCodeAt(0) - 'a'.charCodeAt(0);
-    rows[rowIndex] += figureToLetter({
-      figure: square.figure,
-      color: square.color,
-    });
-  });
-  console.log('  a b c d e f g h');
-  console.log(' +-----------------+');
-  rows.forEach((row, index) => {
-    let displayRow = '';
-    for (const char of row) {
-      if (/[rnbqkpRNBQKP]/.test(char)) {
-        displayRow += char + ' ';
-      } else {
-        displayRow += '. ';
-      }
-    }
-    console.log(`${8 - index}| ${displayRow}|`);
-  });
-  console.log(' +-----------------+');
-};
+// import { Board, Square } from './types.ts';
+// import { figureToLetter } from './board.ts';
+// export const printBoard = (board: Board): void => {
+//   const rows: string[] = Array(8).fill('');
+//   board.forEach((square) => {
+//     const rowIndex = 8 - square.column;
+//     const colIndex = square.row.charCodeAt(0) - 'a'.charCodeAt(0);
+//     rows[rowIndex] += figureToLetter({
+//       figure: square.figure,
+//       color: square.color,
+//     });
+//   });
+//   console.log('  a b c d e f g h');
+//   console.log(' +-----------------+');
+//   rows.forEach((row, index) => {
+//     let displayRow = '';
+//     for (const char of row) {
+//       if (/[rnbqkpRNBQKP]/.test(char)) {
+//         displayRow += char + ' ';
+//       } else {
+//         displayRow += '. ';
+//       }
+//     }
+//     console.log(`${8 - index}| ${displayRow}|`);
+//   });
+//   console.log(' +-----------------+');
+// };

--- a/src/geometry/print.ts
+++ b/src/geometry/print.ts
@@ -1,0 +1,27 @@
+import { Board, Square } from './types.ts';
+import { figureToLetter } from './board.ts';
+export const printBoard = (board: Board): void => {
+  const rows: string[] = Array(8).fill('');
+  board.forEach((square) => {
+    const rowIndex = 8 - square.column;
+    const colIndex = square.row.charCodeAt(0) - 'a'.charCodeAt(0);
+    rows[rowIndex] += figureToLetter({
+      figure: square.figure,
+      color: square.color,
+    });
+  });
+  console.log('  a b c d e f g h');
+  console.log(' +-----------------+');
+  rows.forEach((row, index) => {
+    let displayRow = '';
+    for (const char of row) {
+      if (/[rnbqkpRNBQKP]/.test(char)) {
+        displayRow += char + ' ';
+      } else {
+        displayRow += '. ';
+      }
+    }
+    console.log(`${8 - index}| ${displayRow}|`);
+  });
+  console.log(' +-----------------+');
+};

--- a/src/geometry/transform.ts
+++ b/src/geometry/transform.ts
@@ -1,0 +1,77 @@
+import { FigureLetter, Piece, Row, Column, Position } from './types.ts';
+import { match } from 'ts-pattern';
+export const letterToFigure = (letter: FigureLetter): Piece =>
+  match<FigureLetter, Piece>(letter)
+    .with('P', () => ({ figure: 'PAWN', color: 'white' }))
+    .with('N', () => ({ figure: 'KNIGHT', color: 'white' }))
+    .with('B', () => ({ figure: 'BISHOP', color: 'white' }))
+    .with('R', () => ({ figure: 'ROOK', color: 'white' }))
+    .with('K', () => ({ figure: 'KING', color: 'white' }))
+    .with('Q', () => ({ figure: 'QUEEN', color: 'white' }))
+
+    .with('p', () => ({ figure: 'PAWN', color: 'black' }))
+    .with('n', () => ({ figure: 'KNIGHT', color: 'black' }))
+    .with('b', () => ({ figure: 'BISHOP', color: 'black' }))
+    .with('r', () => ({ figure: 'ROOK', color: 'black' }))
+    .with('k', () => ({ figure: 'KING', color: 'black' }))
+    .with('q', () => ({ figure: 'QUEEN', color: 'black' }))
+    .exhaustive();
+export const figureToLetter = (piece: Piece): FigureLetter =>
+  match<Piece, FigureLetter>(piece)
+    .with({ figure: 'PAWN', color: 'white' }, () => 'P')
+    .with({ figure: 'KNIGHT', color: 'white' }, () => 'N')
+    .with({ figure: 'BISHOP', color: 'white' }, () => 'B')
+    .with({ figure: 'ROOK', color: 'white' }, () => 'R')
+    .with({ figure: 'KING', color: 'white' }, () => 'K')
+    .with({ figure: 'QUEEN', color: 'white' }, () => 'Q')
+    .with({ figure: 'PAWN', color: 'black' }, () => 'p')
+    .with({ figure: 'KNIGHT', color: 'black' }, () => 'n')
+    .with({ figure: 'BISHOP', color: 'black' }, () => 'b')
+    .with({ figure: 'ROOK', color: 'black' }, () => 'r')
+    .with({ figure: 'KING', color: 'black' }, () => 'k')
+    .with({ figure: 'QUEEN', color: 'black' }, () => 'q')
+    .otherwise(() => {
+      throw new Error('Invalid piece');
+    });
+
+export const coordinateToPosition = (
+  col_x: number,
+  row_y: number,
+): Position => ({
+  row: match<number, Row>(row_y)
+    .with(1, () => 'a')
+    .with(2, () => 'b')
+    .with(3, () => 'c')
+    .with(4, () => 'd')
+    .with(5, () => 'e')
+    .with(6, () => 'f')
+    .with(7, () => 'g')
+    .with(8, () => 'h')
+    .otherwise(() => {
+      throw new Error('Invalid row number');
+    }),
+  column: match<number, Column>(col_x)
+    .with(1, () => 1)
+    .with(2, () => 2)
+    .with(3, () => 3)
+    .with(4, () => 4)
+    .with(5, () => 5)
+    .with(6, () => 6)
+    .with(7, () => 7)
+    .with(8, () => 8)
+    .otherwise(() => {
+      throw new Error('Invalid column number');
+    }),
+});
+export const rowToIndex = (row: Row): number =>
+  match<Row, number>(row)
+    .with('a', () => 1)
+    .with('b', () => 2)
+    .with('c', () => 3)
+    .with('d', () => 4)
+    .with('e', () => 5)
+    .with('f', () => 6)
+    .with('g', () => 7)
+    .with('h', () => 8)
+    .exhaustive();
+export const columnToIndex = (column: Column): number => column;

--- a/src/geometry/transform.ts
+++ b/src/geometry/transform.ts
@@ -1,8 +1,6 @@
 import { FigureLetter, Piece, Row, Column, Position, CY, CX } from './types.ts';
 import { match } from 'ts-pattern';
 
-
-
 export const letterToFigure = (letter: string): Piece =>
   match<string, Piece>(letter)
     .with('P', () => ({ figure: 'PAWN', color: 'white' }))
@@ -79,3 +77,8 @@ export const columnToIndex = (col: Column): CX =>
     .with('h', () => 8)
     .exhaustive();
 export const rowToIndex = (row: Row): CY => row;
+
+export const enPassentColumnToIndex = (col: Column | '-'): CX =>
+  match<Column | '-', CX>(col)
+    .with('-', () => -Infinity)
+    .otherwise(() => columnToIndex(col as Column));

--- a/src/geometry/transform.ts
+++ b/src/geometry/transform.ts
@@ -1,4 +1,4 @@
-import { FigureLetter, Piece, Row, Column, Position } from './types.ts';
+import { FigureLetter, Piece, Row, Column, Position, CY, CX } from './types.ts';
 import { match } from 'ts-pattern';
 export const letterToFigure = (letter: FigureLetter): Piece =>
   match<FigureLetter, Piece>(letter)
@@ -35,7 +35,7 @@ export const figureToLetter = (piece: Piece): FigureLetter =>
     });
 
 export const coordinateToPosition = (col_x: number, row_y: number): Position => ({
-  row: match<number, Row>(row_y)
+  column: match<number, Column>(row_y)
     .with(1, () => 'a')
     .with(2, () => 'b')
     .with(3, () => 'c')
@@ -47,7 +47,7 @@ export const coordinateToPosition = (col_x: number, row_y: number): Position => 
     .otherwise(() => {
       throw new Error('Invalid row number');
     }),
-  column: match<number, Column>(col_x)
+  row: match<number, Row>(col_x)
     .with(1, () => 1)
     .with(2, () => 2)
     .with(3, () => 3)
@@ -60,8 +60,8 @@ export const coordinateToPosition = (col_x: number, row_y: number): Position => 
       throw new Error('Invalid column number');
     }),
 });
-export const rowToIndex = (row: Row): number =>
-  match<Row, number>(row)
+export const columnToIndex = (col: Column): CX =>
+  match<Column, number>(col)
     .with('a', () => 1)
     .with('b', () => 2)
     .with('c', () => 3)
@@ -71,4 +71,4 @@ export const rowToIndex = (row: Row): number =>
     .with('g', () => 7)
     .with('h', () => 8)
     .exhaustive();
-export const columnToIndex = (column: Column): number => column;
+export const rowToIndex = (row: Row): CY => row;

--- a/src/geometry/transform.ts
+++ b/src/geometry/transform.ts
@@ -1,7 +1,10 @@
 import { FigureLetter, Piece, Row, Column, Position, CY, CX } from './types.ts';
 import { match } from 'ts-pattern';
-export const letterToFigure = (letter: FigureLetter): Piece =>
-  match<FigureLetter, Piece>(letter)
+
+
+
+export const letterToFigure = (letter: string): Piece =>
+  match<string, Piece>(letter)
     .with('P', () => ({ figure: 'PAWN', color: 'white' }))
     .with('N', () => ({ figure: 'KNIGHT', color: 'white' }))
     .with('B', () => ({ figure: 'BISHOP', color: 'white' }))
@@ -15,7 +18,10 @@ export const letterToFigure = (letter: FigureLetter): Piece =>
     .with('r', () => ({ figure: 'ROOK', color: 'black' }))
     .with('k', () => ({ figure: 'KING', color: 'black' }))
     .with('q', () => ({ figure: 'QUEEN', color: 'black' }))
-    .exhaustive();
+    .otherwise(() => {
+      throw new Error(`Invalid figure letter: ${letter}`);
+    });
+
 export const figureToLetter = (piece: Piece): FigureLetter =>
   match<Piece, FigureLetter>(piece)
     .with({ figure: 'PAWN', color: 'white' }, () => 'P')
@@ -24,6 +30,7 @@ export const figureToLetter = (piece: Piece): FigureLetter =>
     .with({ figure: 'ROOK', color: 'white' }, () => 'R')
     .with({ figure: 'KING', color: 'white' }, () => 'K')
     .with({ figure: 'QUEEN', color: 'white' }, () => 'Q')
+
     .with({ figure: 'PAWN', color: 'black' }, () => 'p')
     .with({ figure: 'KNIGHT', color: 'black' }, () => 'n')
     .with({ figure: 'BISHOP', color: 'black' }, () => 'b')
@@ -35,7 +42,7 @@ export const figureToLetter = (piece: Piece): FigureLetter =>
     });
 
 export const coordinateToPosition = (col_x: number, row_y: number): Position => ({
-  column: match<number, Column>(row_y)
+  column: match<number, Column>(col_x)
     .with(1, () => 'a')
     .with(2, () => 'b')
     .with(3, () => 'c')
@@ -47,7 +54,7 @@ export const coordinateToPosition = (col_x: number, row_y: number): Position => 
     .otherwise(() => {
       throw new Error('Invalid row number');
     }),
-  row: match<number, Row>(col_x)
+  row: match<number, Row>(row_y)
     .with(1, () => 1)
     .with(2, () => 2)
     .with(3, () => 3)
@@ -57,7 +64,7 @@ export const coordinateToPosition = (col_x: number, row_y: number): Position => 
     .with(7, () => 7)
     .with(8, () => 8)
     .otherwise(() => {
-      throw new Error('Invalid column number');
+      throw new Error(`Invalid column number ${col_x}`);
     }),
 });
 export const columnToIndex = (col: Column): CX =>

--- a/src/geometry/transform.ts
+++ b/src/geometry/transform.ts
@@ -34,10 +34,7 @@ export const figureToLetter = (piece: Piece): FigureLetter =>
       throw new Error('Invalid piece');
     });
 
-export const coordinateToPosition = (
-  col_x: number,
-  row_y: number,
-): Position => ({
+export const coordinateToPosition = (col_x: number, row_y: number): Position => ({
   row: match<number, Row>(row_y)
     .with(1, () => 'a')
     .with(2, () => 'b')

--- a/src/geometry/transform.ts
+++ b/src/geometry/transform.ts
@@ -39,7 +39,7 @@ export const figureToLetter = (piece: Piece): FigureLetter =>
       throw new Error('Invalid piece');
     });
 
-export const coordinateToPosition = (col_x: number, row_y: number): Position => ({
+export const coordinateToPosition = (col_x: CX, row_y: CY): Position => ({
   column: match<number, Column>(col_x)
     .with(1, () => 'a')
     .with(2, () => 'b')

--- a/src/geometry/transform.ts
+++ b/src/geometry/transform.ts
@@ -52,7 +52,7 @@ export const coordinateToPosition = (col_x: number, row_y: number): Position => 
     .with(7, () => 'g')
     .with(8, () => 'h')
     .otherwise(() => {
-      throw new Error('Invalid row number');
+      throw new Error(`Invalid column number ${col_x}`);
     }),
   row: match<number, Row>(row_y)
     .with(1, () => 1)
@@ -64,7 +64,7 @@ export const coordinateToPosition = (col_x: number, row_y: number): Position => 
     .with(7, () => 7)
     .with(8, () => 8)
     .otherwise(() => {
-      throw new Error(`Invalid column number ${col_x}`);
+      throw new Error(`Invalid row number ${row_y}`);
     }),
 });
 export const columnToIndex = (col: Column): CX =>

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -14,7 +14,7 @@ export type Position = {
   row: Row;
   column: Column;
 };
-export type Move = Position & { isTaken?: boolean };
+export type Move = Position & { isTaken?: boolean; isTakenEnPassent?: boolean };
 export type Piece = {
   color: Color;
   figure: Figure;

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,5 +1,5 @@
-export const Rows = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
-export const Columns = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+export const Rows = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+export const Columns = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
 export const FigureLetters = ['k', 'q', 'r', 'b', 'n', 'p', 'K', 'Q', 'R', 'B', 'N', 'P'] as const;
 
 export type Row = (typeof Rows)[number];
@@ -26,3 +26,23 @@ export type BoardPieceMap = (Piece | null)[][];
 
 export type CX = number; //Coord X
 export type CY = number; //Coord Y
+
+export type Pgn = string[]; //e4 e5 Nf3 Nc6 Bb5 a6 ...
+export type FEN = string; //rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 // should be called Fen
+
+export type Game = {
+  id: string;
+  history: FEN[];
+  turn: Color;
+
+  lastMoveTwoPawnStep: boolean; //will be used for en passant at pawn move
+
+  //might not be needed
+  whiteKingSideCastle: boolean;
+  whiteQueenSideCastle: boolean;
+  blackKingSideCastle: boolean;
+  blackQueenSideCastle: boolean;
+
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,16 +1,41 @@
-export type row = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h';
-export type column = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-export type piece =
-  | 'PAWN'
-  | 'KNIGHT'
-  | 'BISHOP'
-  | 'ROOK'
-  | 'KING'
-  | 'QUEEN'
-  | 'NONE';
+export const Rows = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
+export const Columns = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+export const FigureLetters = [
+  'k',
+  'q',
+  'r',
+  'b',
+  'n',
+  'p',
+  'K',
+  'Q',
+  'R',
+  'B',
+  'N',
+  'P',
+] as const;
 
-export type square = {
-  piece: piece;
-  row: row;
-  column: column;
+export type Row = (typeof Rows)[number];
+export type Column = (typeof Columns)[number];
+export type FigureLetter = (typeof FigureLetters)[number];
+
+export type Color = 'white' | 'black' | 'none';
+export type Figure = 'PAWN' | 'KNIGHT' | 'BISHOP' | 'ROOK' | 'KING' | 'QUEEN';
+
+export type Position = {
+  row: Row;
+  column: Column;
 };
+export type Move = Position & { isTaken?: boolean };
+export type Piece = {
+  color: Color;
+  figure: Figure;
+};
+
+export type Square = Position & Piece;
+export type Board = Square[];
+export type BoardColorMap = Color[][];
+export type BoardPieceMap = (Piece | null)[][];
+
+export type CX = number; //Coord X
+export type CY = number; //Coord Y

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -28,11 +28,11 @@ export type CX = number; //Coord X
 export type CY = number; //Coord Y
 
 export type Pgn = string[]; //e4 e5 Nf3 Nc6 Bb5 a6 ...
-export type FEN = string; //rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 // should be called Fen
+export type Fen = string; //rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 // should be called Fen
 
 export type Game = {
   id: string;
-  history: FEN[];
+  history: Fen[];
   turn: Color;
 
   lastMoveTwoPawnStep: boolean; //will be used for en passant at pawn move

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,11 +1,13 @@
 export const Rows = [1, 2, 3, 4, 5, 6, 7, 8] as const;
 export const Columns = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
 export const FigureLetters = ['k', 'q', 'r', 'b', 'n', 'p', 'K', 'Q', 'R', 'B', 'N', 'P'] as const;
+export const CastlingLetters = ['K', 'Q', 'k', 'q'] as const;
 
 export type Row = (typeof Rows)[number];
 export type Column = (typeof Columns)[number];
 export type FigureLetter = (typeof FigureLetters)[number];
 export type EnPassentColumn = Column | '-';
+export type CastlingLetter = (typeof CastlingLetters)[number] | '-';
 
 export type Color = 'white' | 'black' | 'none';
 export type Figure = 'PAWN' | 'KNIGHT' | 'BISHOP' | 'ROOK' | 'KING' | 'QUEEN';
@@ -14,7 +16,13 @@ export type Position = {
   row: Row;
   column: Column;
 };
-export type Move = Position & { isTaken?: boolean; isTakenEnPassent?: boolean };
+export type MoveProperties = {
+  isTaken?: boolean;
+  isTakenEnPassent?: boolean;
+  isPromotion?: boolean;
+  castling?: CastlingLetter;
+};
+export type Move = Position & MoveProperties; //extra info for move
 export type Piece = {
   color: Color;
   figure: Figure;

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -5,6 +5,7 @@ export const FigureLetters = ['k', 'q', 'r', 'b', 'n', 'p', 'K', 'Q', 'R', 'B', 
 export type Row = (typeof Rows)[number];
 export type Column = (typeof Columns)[number];
 export type FigureLetter = (typeof FigureLetters)[number];
+export type EnPassentColumn = Column | '-';
 
 export type Color = 'white' | 'black' | 'none';
 export type Figure = 'PAWN' | 'KNIGHT' | 'BISHOP' | 'ROOK' | 'KING' | 'QUEEN';

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -1,19 +1,6 @@
 export const Rows = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const;
 export const Columns = [1, 2, 3, 4, 5, 6, 7, 8] as const;
-export const FigureLetters = [
-  'k',
-  'q',
-  'r',
-  'b',
-  'n',
-  'p',
-  'K',
-  'Q',
-  'R',
-  'B',
-  'N',
-  'P',
-] as const;
+export const FigureLetters = ['k', 'q', 'r', 'b', 'n', 'p', 'K', 'Q', 'R', 'B', 'N', 'P'] as const;
 
 export type Row = (typeof Rows)[number];
 export type Column = (typeof Columns)[number];

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -27,6 +27,8 @@ export type BoardPieceMap = (Piece | null)[][];
 export type CX = number; //Coord X
 export type CY = number; //Coord Y
 
+export type Direction = { row: CX; col: CY };
+
 export type Pgn = string[]; //e4 e5 Nf3 Nc6 Bb5 a6 ...
 export type Fen = string; //rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 // should be called Fen
 

--- a/src/geometry/types.ts
+++ b/src/geometry/types.ts
@@ -20,7 +20,7 @@ export type MoveProperties = {
   isTaken?: boolean;
   isTakenEnPassent?: boolean;
   isPromotion?: boolean;
-  castling?: CastlingLetter;
+  isCastle?: CastlingLetter;
 };
 export type Move = Position & MoveProperties; //extra info for move
 export type Piece = {


### PR DESCRIPTION
This pull request introduces new comprehensive tests for chess board creation and king-in-check logic, improves code formatting consistency, and updates package scripts and dependencies. The most impactful changes are the addition of detailed test cases for chess board and check detection functionality, alongside enhancements to developer tooling and documentation.

### Chess Logic Testing

* Added `board.test.ts` with tests for creating chess boards from FEN strings, and verifying board-to-piece and board-to-color map conversions. These tests cover both the initial position and positions with moved pawns, ensuring correctness of board setup and mapping functions.
* Added `check.test.ts` with extensive tests for `isKingChecked`, `isPositionChecked`, and `wouldPositionBeChecked`. The tests validate detection of checks by bishops, queens, rooks, knights, pawns (in all directions), and kings, as well as hypothetical and edge-case scenarios.

### Developer Tooling & Formatting

* Updated `.prettierrc.json` to increase `printWidth` for better code readability and maintain consistent formatting.
* Added `.vscode/settings.json` to enable automatic formatting on save using Prettier, improving code consistency for all contributors.
* Streamlined formatting rules in `eslint.config.js` for better readability and maintainability.

### Build & Test Configuration

* Simplified and compacted `babel.config.js` for easier configuration management.
* Updated `package.json` scripts to add targeted geometry tests and adjusted the main test script to show output, plus added `ts-pattern` to dependencies for pattern matching.

### Documentation

* Clarified testing instructions in `README.md` to better explain the use of Babel and alternatives for running tests in a Node.js environment.